### PR TITLE
feat: add world tilemap and HUD

### DIFF
--- a/scenes/ui/Hud.tscn
+++ b/scenes/ui/Hud.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=2]
+
+[ext_resource path="res://scripts/ui/Hud.gd" type="Script" id="1"]
+
+[node name="Hud" type="CanvasLayer" script=ExtResource("1")]
+
+[node name="ResourcesLabel" type="Label" parent="."]
+text = "Money: 0 Ammo: 0"
+
+[node name="StartButton" type="Button" parent="."]
+text = "Start"
+
+[node name="PauseButton" type="Button" parent="."]
+text = "Pause"
+
+[node name="ClockLabel" type="Label" parent="."]
+text = "Time: 0"

--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -1,3 +1,13 @@
-[gd_scene]
+[gd_scene load_steps=4]
 
-[node name="World" type="Node"]
+[ext_resource path="res://scripts/world/World.gd" type="Script" id="1"]
+[ext_resource path="res://scripts/core/GameClock.gd" type="Script" id="2"]
+[ext_resource path="res://scenes/ui/Hud.tscn" type="PackedScene" id="3"]
+
+[node name="World" type="Node2D" script=ExtResource("1")]
+
+[node name="GameClock" type="Node" parent="." script=ExtResource("2")]
+
+[node name="LaneTileMap" type="TileMap" parent="."]
+
+[node name="Hud" parent="." instance=ExtResource("3")]

--- a/scripts/core/GameClock.gd
+++ b/scripts/core/GameClock.gd
@@ -1,0 +1,17 @@
+extends Node
+
+signal tick(time: float)
+
+var time: float = 0.0
+var running: bool = false
+
+func _process(delta: float) -> void:
+    if running:
+        time += delta
+        tick.emit(time)
+
+func start() -> void:
+    running = true
+
+func stop() -> void:
+    running = false

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -1,0 +1,19 @@
+extends CanvasLayer
+
+signal start_pressed
+signal pause_pressed
+
+@onready var resources_label: Label = $ResourcesLabel
+@onready var start_button: Button = $StartButton
+@onready var pause_button: Button = $PauseButton
+@onready var clock_label: Label = $ClockLabel
+
+func _ready() -> void:
+    start_button.pressed.connect(func(): start_pressed.emit())
+    pause_button.pressed.connect(func(): pause_pressed.emit())
+
+func update_resources(money: int, ammo: int) -> void:
+    resources_label.text = "Money: %d Ammo: %d" % [money, ammo]
+
+func update_clock(time: float) -> void:
+    clock_label.text = "Time: %.2f" % time

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -1,0 +1,13 @@
+extends Node2D
+
+@onready var hud: CanvasLayer = $Hud
+@onready var game_clock: Node = $GameClock
+
+var money: int = 0
+var ammo: int = 0
+
+func _ready() -> void:
+    hud.start_pressed.connect(game_clock.start)
+    hud.pause_pressed.connect(game_clock.stop)
+    game_clock.tick.connect(hud.update_clock)
+    hud.update_resources(money, ammo)


### PR DESCRIPTION
## Summary
- add World node with TileMap and HUD instance
- implement GameClock and HUD scripts with resource displays and controls
- wire HUD signals to drive GameClock timing

## Testing
- `godot --headless -s addons/gut/gut_cmdln.gd -gdir=res://tests` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0528833088330b4b91df4fb60c2ff