### PR TITLE
feat: enable building construction and resource production

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -1,7 +1,8 @@
 extends Node
 
 var res := {
-    "wood": 0.0,
+    "gold": 100.0,
+    "wood": 100.0,
     "food": 0.0,
     "research": 0.0,
     "influence": 0.0,

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -12,8 +12,11 @@ func _ready() -> void:
     start_button.pressed.connect(func(): start_pressed.emit())
     pause_button.pressed.connect(func(): pause_pressed.emit())
 
-func update_resources(money: int, ammo: int) -> void:
-    resources_label.text = "Money: %d Ammo: %d" % [money, ammo]
+func update_resources(resources: Dictionary) -> void:
+    var parts: PackedStringArray = []
+    for key in resources.keys().sorted():
+        parts.append("%s: %d" % [key.capitalize(), int(resources[key])])
+    resources_label.text = " ".join(parts)
 
 func update_clock(time: float) -> void:
     clock_label.text = "Time: %.2f" % time

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -3,11 +3,28 @@ extends Node2D
 @onready var hud: CanvasLayer = $Hud
 @onready var game_clock: Node = $GameClock
 
-var money: int = 0
-var ammo: int = 0
+const FARM_BUILDING: Resource = preload("res://resources/buildings/farm.tres")
+
+var owned_buildings: Array[Building] = []
 
 func _ready() -> void:
     hud.start_pressed.connect(game_clock.start)
     hud.pause_pressed.connect(game_clock.stop)
-    game_clock.tick.connect(hud.update_clock)
-    hud.update_resources(money, ammo)
+    game_clock.tick.connect(_on_tick)
+    hud.update_resources(GameState.res)
+    construct_building(FARM_BUILDING)
+
+func construct_building(building_res: Resource) -> void:
+    var building: Building = building_res.duplicate(true) as Building
+    var cost := building.get_construction_cost()
+    for res_name in cost.keys():
+        GameState.res[res_name] = GameState.res.get(res_name, 0) - cost[res_name]
+    owned_buildings.append(building)
+    hud.update_resources(GameState.res)
+
+func _on_tick(time: float) -> void:
+    for building in owned_buildings:
+        for res_name in building.get_production_rates().keys():
+            GameState.res[res_name] = GameState.res.get(res_name, 0) + building.get_production_rates()[res_name]
+    hud.update_resources(GameState.res)
+    hud.update_clock(time)


### PR DESCRIPTION
## Summary
- track gold and wood in `GameState` with starting amounts
- show dynamic resource values on HUD
- allow constructing farm buildings and produce resources each tick

## Testing
- `gdlint scripts/world/World.gd scripts/ui/Hud.gd autoload/GameState.gd` *(fails: command not found)*
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c055880c70833095e1fa41f3d508da