### PR TITLE
Add hex tile scene and map generator

### DIFF
--- a/scenes/world/HexTile.tscn
+++ b/scenes/world/HexTile.tscn
@@ -1,0 +1,5 @@
+[gd_scene load_steps=2]
+
+[ext_resource path="res://scripts/world/HexTile.gd" type="Script" id="1"]
+
+[node name="HexTile" type="Node2D" script=ExtResource("1")]

--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4]
+[gd_scene load_steps=5]
 
 [ext_resource path="res://scripts/world/World.gd" type="Script" id="1"]
 [ext_resource path="res://scripts/core/GameClock.gd" type="Script" id="2"]
 [ext_resource path="res://scenes/ui/Hud.tscn" type="PackedScene" id="3"]
+[ext_resource path="res://scripts/world/MapGenerator.gd" type="Script" id="4"]
 
 [node name="World" type="Node2D" script=ExtResource("1")]
 
@@ -11,3 +12,8 @@
 [node name="LaneTileMap" type="TileMap" parent="."]
 
 [node name="Hud" parent="." instance=ExtResource("3")]
+
+[node name="MapGenerator" type="Node2D" parent="." script=ExtResource("4")]
+map_width = 8
+map_height = 8
+seed = 1

--- a/scripts/world/HexTile.gd
+++ b/scripts/world/HexTile.gd
@@ -1,0 +1,6 @@
+extends Node2D
+
+@export var q: int = 0
+@export var r: int = 0
+@export var terrain: String = "plain"
+@export var resource: String = ""

--- a/scripts/world/MapGenerator.gd
+++ b/scripts/world/MapGenerator.gd
@@ -1,0 +1,45 @@
+extends Node2D
+
+@export var map_width: int = 10
+@export var map_height: int = 10
+@export var seed: int = 0
+@export var hex_radius: float = 32.0
+
+var noise := FastNoiseLite.new()
+var rng := RandomNumberGenerator.new()
+@onready var hex_tile_scene: PackedScene = preload("res://scenes/world/HexTile.tscn")
+
+func _ready() -> void:
+    noise.seed = seed
+    rng.seed = seed
+    generate_map()
+
+func axial_to_world(q: int, r: int) -> Vector2:
+    var x := hex_radius * sqrt(3.0) * (q + r / 2.0)
+    var y := hex_radius * 1.5 * r
+    return Vector2(x, y)
+
+func generate_map() -> void:
+    for child in get_children():
+        child.queue_free()
+    for r in map_height:
+        for q in map_width:
+            var hex: Node2D = hex_tile_scene.instantiate() as Node2D
+            var noise_val := noise.get_noise_2d(float(q), float(r))
+            var terrain_type := "water"
+            if noise_val > 0.4:
+                terrain_type = "mountain"
+            elif noise_val > 0.0:
+                terrain_type = "grass"
+            var resource_type := ""
+            var roll := rng.randf()
+            if roll < 0.1:
+                resource_type = "gold"
+            elif roll < 0.25:
+                resource_type = "wood"
+            hex.q = q
+            hex.r = r
+            hex.terrain = terrain_type
+            hex.resource = resource_type
+            hex.position = axial_to_world(q, r)
+            add_child(hex)


### PR DESCRIPTION
## Summary
- Create `HexTile` scene and script to hold axial coordinates plus terrain and resource info.
- Add `MapGenerator` for deterministic hex map creation, positioning tiles and assigning terrain via noise with optional resources.
- Connect `MapGenerator` into `World.tscn` so maps generate on load.

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68c057af5770833082e38ad94bbbea9d