### PR TITLE
Add tile selection and resource production tracking

### DIFF
--- a/scenes/ui/Hud.tscn
+++ b/scenes/ui/Hud.tscn
@@ -7,6 +7,9 @@
 [node name="ResourcesLabel" type="Label" parent="."]
 text = "Money: 0 Ammo: 0"
 
+[node name="TileInfoLabel" type="Label" parent="."]
+text = "Tile: (0,0) - Empty"
+
 [node name="StartButton" type="Button" parent="."]
 text = "Start"
 

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -4,19 +4,32 @@ signal start_pressed
 signal pause_pressed
 
 @onready var resources_label: Label = $ResourcesLabel
+@onready var tile_info_label: Label = $TileInfoLabel
 @onready var start_button: Button = $StartButton
 @onready var pause_button: Button = $PauseButton
 @onready var clock_label: Label = $ClockLabel
 
+
 func _ready() -> void:
-    start_button.pressed.connect(func(): start_pressed.emit())
-    pause_button.pressed.connect(func(): pause_pressed.emit())
+	start_button.pressed.connect(func(): start_pressed.emit())
+	pause_button.pressed.connect(func(): pause_pressed.emit())
+
 
 func update_resources(resources: Dictionary) -> void:
-    var parts: PackedStringArray = []
-    for key in resources.keys().sorted():
-        parts.append("%s: %d" % [key.capitalize(), int(resources[key])])
-    resources_label.text = " ".join(parts)
+	var parts: PackedStringArray = []
+	for key in resources.keys().sorted():
+		parts.append("%s: %d" % [key.capitalize(), int(resources[key])])
+	resources_label.text = " ".join(parts)
+
+
+func update_tile(tile_pos: Vector2i, building: Building) -> void:
+	var text := "Tile: (%d,%d)" % [tile_pos.x, tile_pos.y]
+	if building:
+		text += " - %s" % building.name
+	else:
+		text += " - Empty"
+	tile_info_label.text = text
+
 
 func update_clock(time: float) -> void:
-    clock_label.text = "Time: %.2f" % time
+	clock_label.text = "Time: %.2f" % time

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -1,30 +1,49 @@
 extends Node2D
 
-@onready var hud: CanvasLayer = $Hud
-@onready var game_clock: Node = $GameClock
-
 const FARM_BUILDING: Resource = preload("res://resources/buildings/farm.tres")
 
-var owned_buildings: Array[Building] = []
+var selected_tile: Vector2i = Vector2i.ZERO
+var tile_occupants: Dictionary = {}
+
+@onready var hud: CanvasLayer = $Hud
+@onready var game_clock: Node = $GameClock
+@onready var tile_map: TileMap = $LaneTileMap
+
 
 func _ready() -> void:
-    hud.start_pressed.connect(game_clock.start)
-    hud.pause_pressed.connect(game_clock.stop)
-    game_clock.tick.connect(_on_tick)
-    hud.update_resources(GameState.res)
-    construct_building(FARM_BUILDING)
+	hud.start_pressed.connect(game_clock.start)
+	hud.pause_pressed.connect(game_clock.stop)
+	game_clock.tick.connect(_on_tick)
+	hud.update_resources(GameState.res)
+	hud.update_tile(selected_tile, null)
 
-func construct_building(building_res: Resource) -> void:
-    var building: Building = building_res.duplicate(true) as Building
-    var cost := building.get_construction_cost()
-    for res_name in cost.keys():
-        GameState.res[res_name] = GameState.res.get(res_name, 0) - cost[res_name]
-    owned_buildings.append(building)
-    hud.update_resources(GameState.res)
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		var pos: Vector2 = tile_map.to_local(event.position)
+		selected_tile = tile_map.local_to_map(pos)
+		hud.update_tile(selected_tile, tile_occupants.get(selected_tile))
+	elif event is InputEventKey and event.pressed and event.keycode == KEY_B:
+		construct_building(FARM_BUILDING, selected_tile)
+
+
+func construct_building(building_res: Resource, tile_pos: Vector2i) -> void:
+	if tile_occupants.has(tile_pos):
+		return
+	var building: Building = building_res.duplicate(true) as Building
+	var cost := building.get_construction_cost()
+	for res_name in cost.keys():
+		GameState.res[res_name] = GameState.res.get(res_name, 0) - cost[res_name]
+	tile_occupants[tile_pos] = building
+	hud.update_resources(GameState.res)
+	hud.update_tile(tile_pos, building)
+
 
 func _on_tick(time: float) -> void:
-    for building in owned_buildings:
-        for res_name in building.get_production_rates().keys():
-            GameState.res[res_name] = GameState.res.get(res_name, 0) + building.get_production_rates()[res_name]
-    hud.update_resources(GameState.res)
-    hud.update_clock(time)
+	for building in tile_occupants.values():
+		for res_name in building.get_production_rates().keys():
+			GameState.res[res_name] = (
+				GameState.res.get(res_name, 0) + building.get_production_rates()[res_name]
+			)
+	hud.update_resources(GameState.res)
+	hud.update_clock(time)


### PR DESCRIPTION
## Summary
- add tile selection and building placement with resource costs
- aggregate building production each tick
- display tile details and resources in HUD

## Testing
- `gdlint scripts/world/World.gd scripts/ui/Hud.gd`
- `gdformat scripts/world/World.gd scripts/ui/Hud.gd scenes/ui/Hud.tscn` *(fails to format .tscn but scripts formatted)*

------
https://chatgpt.com/codex/tasks/task_e_68c057d7c134833097da0c9ecd0bd09e