### PR TITLE
Add simple test framework and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Vertical slice WIP: 3 buildings, 3 units, 3 lanes, 1 neighbor AI, prestige stub,
 2. Press ▶ to run
 3. Exports via export_presets.cfg (to be added)
 
+## Testing
+Run automated tests in headless mode:
+
+```
+godot4 --headless -s tests/test_runner.gd
+```
+
 ## Controls
 Mouse-only prototype:  
 - Left panel: build  

--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -19,7 +19,7 @@ var last_timestamp: int = 0
 const SAVE_PATH := "user://save.json"
 
 func _ready() -> void:
-    load()
+    load_state()
 
 func save() -> void:
     last_timestamp = Time.get_unix_time_from_system()
@@ -33,7 +33,7 @@ func save() -> void:
         file.store_string(JSON.stringify(data))
         file.close()
 
-func load() -> void:
+func load_state() -> void:
     if not FileAccess.file_exists(SAVE_PATH):
         last_timestamp = Time.get_unix_time_from_system()
         return

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -16,10 +16,12 @@ func _ready() -> void:
 
 
 func update_resources(resources: Dictionary) -> void:
-	var parts: PackedStringArray = []
-	for key in resources.keys().sorted():
-		parts.append("%s: %d" % [key.capitalize(), int(resources[key])])
-	resources_label.text = " ".join(parts)
+        var keys := resources.keys()
+        keys.sort()
+        var parts: PackedStringArray = []
+        for key in keys:
+                parts.append("%s: %d" % [key.capitalize(), int(resources[key])])
+        resources_label.text = " ".join(parts)
 
 
 func update_tile(tile_pos: Vector2i, building: Building) -> void:

--- a/tests/test_game_clock.gd
+++ b/tests/test_game_clock.gd
@@ -1,0 +1,18 @@
+extends Node
+var GameClock = preload("res://scripts/core/GameClock.gd")
+
+func test_process_increments_time_when_running(res):
+    var clock = GameClock.new()
+    clock.start()
+    clock._process(0.5)
+    if clock.time != 0.5:
+        res.fail("Time after first process")
+    clock._process(0.25)
+    if clock.time != 0.75:
+        res.fail("Time after second process")
+
+func test_process_no_increment_when_stopped(res):
+    var clock = GameClock.new()
+    clock._process(1.0)
+    if clock.time != 0.0:
+        res.fail("Time should not advance when stopped")

--- a/tests/test_rng.gd
+++ b/tests/test_rng.gd
@@ -1,0 +1,19 @@
+extends Node
+var RNG = preload("res://autoload/RNG.gd")
+
+func test_seed_generates_same_sequence(res):
+    var rng1 = RNG.new()
+    var rng2 = RNG.new()
+    rng1.seed_from_string("seed")
+    rng2.seed_from_string("seed")
+    if rng1.randi() != rng2.randi():
+        res.fail("First randi should match for same seed")
+    if rng1.randf() != rng2.randf():
+        res.fail("First randf should match for same seed")
+
+func test_randf_between_0_and_1(res):
+    var rng = RNG.new()
+    rng.seed_from_string("demo")
+    var value = rng.randf()
+    if value < 0.0 or value >= 1.0:
+        res.fail("randf should be in [0,1)")

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -1,0 +1,33 @@
+extends SceneTree
+
+class TestResult:
+    var failed := false
+    var message := ""
+    func fail(msg: String) -> void:
+        failed = true
+        message = msg
+
+var test_scripts := [
+    preload("res://tests/test_rng.gd"),
+    preload("res://tests/test_game_clock.gd"),
+]
+
+func _init() -> void:
+    var total := 0
+    var failed_count := 0
+    for script in test_scripts:
+        var obj = script.new()
+        for method in obj.get_method_list():
+            var name = method.name
+            if name.begins_with("test_"):
+                total += 1
+                var res = TestResult.new()
+                obj.call(name, res)
+                if res.failed:
+                    failed_count += 1
+                    print("FAIL: %s.%s - %s" % [script.resource_path, name, res.message])
+    if failed_count == 0:
+        print("All %d tests passed" % total)
+    else:
+        print("%d/%d tests failed" % [failed_count, total])
+    quit(failed_count)


### PR DESCRIPTION
## Summary
- introduce a lightweight GDScript test runner and unit tests for RNG and GameClock
- fix GameState load name clash and HUD resource sorting
- document how to run tests

## Testing
- `godot4 --headless -s tests/test_runner.gd`


------
https://chatgpt.com/codex/tasks/task_e_68c068c778088330892a042b0cbd1dee