### PR TITLE
Add event and policy resources with UI triggers

### DIFF
--- a/resources/events/rain.tres
+++ b/resources/events/rain.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script="res://scripts/events/Event.gd"]
+
+[resource]
+name = "Rain"
+description = "Bountiful rain increases food production."
+effects = {"food": 20}
+costs = {}
+cooldown = 0.0

--- a/resources/policies/tax_relief.tres
+++ b/resources/policies/tax_relief.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script="res://scripts/policies/Policy.gd"]
+
+[resource]
+name = "Tax Relief"
+description = "Spend gold to raise morale."
+costs = {"gold": 20}
+effects = {"morale": 10}
+cooldown = 30.0

--- a/scenes/ui/Hud.tscn
+++ b/scenes/ui/Hud.tscn
@@ -18,3 +18,12 @@ text = "Pause"
 
 [node name="ClockLabel" type="Label" parent="."]
 text = "Time: 0"
+
+[node name="PolicyButton" type="Button" parent="."]
+text = "Use Policy"
+
+[node name="EventButton" type="Button" parent="."]
+text = "Trigger Event"
+
+[node name="EventLabel" type="Label" parent="."]
+text = "No events"

--- a/scripts/events/Event.gd
+++ b/scripts/events/Event.gd
@@ -1,0 +1,29 @@
+extends Resource
+class_name GameEvent
+
+@export var name: String = ""
+@export var description: String = ""
+@export var costs: Dictionary = {}
+@export var effects: Dictionary = {}
+@export var cooldown: float = 0.0
+
+var last_triggered: float = -INF
+
+func can_trigger() -> bool:
+	return Time.get_unix_time_from_system() - last_triggered >= cooldown and _has_resources()
+
+func _has_resources() -> bool:
+	for key in costs.keys():
+		if GameState.res.get(key, 0) < costs[key]:
+			return false
+	return true
+
+func apply() -> bool:
+	if not can_trigger():
+		return false
+	for key in costs.keys():
+		GameState.res[key] = GameState.res.get(key, 0) - costs[key]
+	for key in effects.keys():
+		GameState.res[key] = GameState.res.get(key, 0) + effects[key]
+	last_triggered = Time.get_unix_time_from_system()
+	return true

--- a/scripts/policies/Policy.gd
+++ b/scripts/policies/Policy.gd
@@ -1,0 +1,29 @@
+extends Resource
+class_name Policy
+
+@export var name: String = ""
+@export var description: String = ""
+@export var costs: Dictionary = {}
+@export var effects: Dictionary = {}
+@export var cooldown: float = 0.0
+
+var last_used: float = -INF
+
+func can_apply() -> bool:
+	return Time.get_unix_time_from_system() - last_used >= cooldown and _has_resources()
+
+func _has_resources() -> bool:
+	for key in costs.keys():
+		if GameState.res.get(key, 0) < costs[key]:
+			return false
+	return true
+
+func apply() -> bool:
+	if not can_apply():
+		return false
+	for key in costs.keys():
+		GameState.res[key] = GameState.res.get(key, 0) - costs[key]
+	for key in effects.keys():
+		GameState.res[key] = GameState.res.get(key, 0) + effects[key]
+	last_used = Time.get_unix_time_from_system()
+	return true

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -8,11 +8,16 @@ signal pause_pressed
 @onready var start_button: Button = $StartButton
 @onready var pause_button: Button = $PauseButton
 @onready var clock_label: Label = $ClockLabel
+@onready var policy_button: Button = $PolicyButton
+@onready var event_button: Button = $EventButton
+@onready var event_label: Label = $EventLabel
 
 
 func _ready() -> void:
 	start_button.pressed.connect(func(): start_pressed.emit())
 	pause_button.pressed.connect(func(): pause_pressed.emit())
+	policy_button.pressed.connect(_on_policy_pressed)
+	event_button.pressed.connect(_on_event_pressed)
 
 
 func update_resources(resources: Dictionary) -> void:
@@ -33,3 +38,17 @@ func update_tile(tile_pos: Vector2i, building: Building) -> void:
 
 func update_clock(time: float) -> void:
 	clock_label.text = "Time: %.2f" % time
+
+
+func _on_policy_pressed() -> void:
+	var policy: Policy = load("res://resources/policies/tax_relief.tres")
+	if policy.apply():
+		update_resources(GameState.res)
+
+func _on_event_pressed() -> void:
+	var ev: GameEvent = load("res://resources/events/rain.tres")
+	if ev.apply():
+		update_resources(GameState.res)
+		event_label.text = "%s occurred!" % ev.name
+	else:
+		event_label.text = "%s on cooldown" % ev.name


### PR DESCRIPTION
## Summary
- add generic `GameEvent` and `Policy` resources with cost, effect, and cooldown logic
- define sample `Rain` event and `Tax Relief` policy resources
- extend HUD with buttons to trigger a policy or event and display outcomes

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c069b436788330aab6834b9174d5c5