### PR TITLE
feat: add hex map foundation

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -14,6 +14,8 @@ var meta := {
     "production_mult": 1.0,
 }
 
+var tiles: Dictionary = {}
+
 var last_timestamp: int = 0
 
 const SAVE_PATH := "user://save.json"
@@ -23,9 +25,18 @@ func _ready() -> void:
 
 func save() -> void:
     last_timestamp = Time.get_unix_time_from_system()
+    var tiles_array: Array = []
+    for pos in tiles.keys():
+        var info := tiles[pos]
+        tiles_array.append({
+            "q": pos.x,
+            "r": pos.y,
+            "terrain": info.get("terrain", "")
+        })
     var data := {
         "res": res,
         "meta": meta,
+        "tiles": tiles_array,
         "last_timestamp": last_timestamp,
     }
     var file := FileAccess.open(SAVE_PATH, FileAccess.WRITE)
@@ -49,4 +60,9 @@ func load_state() -> void:
         return
     res = data.get("res", res)
     meta = data.get("meta", meta)
+    tiles.clear()
+    for t in data.get("tiles", []):
+        var q := int(t.get("q", 0))
+        var r := int(t.get("r", 0))
+        tiles[Vector2i(q, r)] = {"terrain": t.get("terrain", ""), "q": q, "r": r}
     last_timestamp = int(data.get("last_timestamp", Time.get_unix_time_from_system()))

--- a/scenes/world/HexMap.tscn
+++ b/scenes/world/HexMap.tscn
@@ -1,0 +1,5 @@
+[gd_scene load_steps=2]
+
+[ext_resource path="res://scripts/world/HexMap.gd" type="Script" id="1"]
+
+[node name="HexMap" type="TileMap" script=ExtResource("1")]

--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -1,19 +1,14 @@
-[gd_scene load_steps=5]
+[gd_scene load_steps=4]
 
 [ext_resource path="res://scripts/world/World.gd" type="Script" id="1"]
 [ext_resource path="res://scripts/core/GameClock.gd" type="Script" id="2"]
 [ext_resource path="res://scenes/ui/Hud.tscn" type="PackedScene" id="3"]
-[ext_resource path="res://scripts/world/MapGenerator.gd" type="Script" id="4"]
+[ext_resource path="res://scenes/world/HexMap.tscn" type="PackedScene" id="4"]
 
 [node name="World" type="Node2D" script=ExtResource("1")]
 
 [node name="GameClock" type="Node" parent="." script=ExtResource("2")]
 
-[node name="LaneTileMap" type="TileMap" parent="."]
+[node name="HexMap" parent="." instance=ExtResource("4")]
 
 [node name="Hud" parent="." instance=ExtResource("3")]
-
-[node name="MapGenerator" type="Node2D" parent="." script=ExtResource("4")]
-map_width = 8
-map_height = 8
-seed = 1

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -1,0 +1,59 @@
+extends TileMap
+
+const RADIUS := 8
+const TERRAIN_WEIGHTS := {
+    "forest": 0.40,
+    "taiga": 0.35,
+    "hill": 0.15,
+    "lake": 0.10,
+}
+const TERRAIN_IDS := {
+    "forest": 0,
+    "taiga": 1,
+    "hill": 2,
+    "lake": 3,
+}
+const TERRAIN_COLORS := {
+    "forest": Color(0.2, 0.6, 0.2),
+    "taiga": Color(0.1, 0.4, 0.1),
+    "hill": Color(0.5, 0.5, 0.5),
+    "lake": Color(0.2, 0.2, 0.8),
+}
+
+func _ready() -> void:
+    _init_tileset()
+    GameState.tiles.clear()
+    randomize()
+    _generate_map()
+
+func _init_tileset() -> void:
+    var ts := TileSet.new()
+    ts.tile_shape = TileSet.TILE_SHAPE_HEXAGON
+    for terrain in TERRAIN_IDS.keys():
+        var img := Image.create(64, 64, false, Image.FORMAT_RGBA8)
+        img.fill(TERRAIN_COLORS[terrain])
+        var tex := ImageTexture.create_from_image(img)
+        var src := TileSetAtlasSource.new()
+        src.texture = tex
+        var id := TERRAIN_IDS[terrain]
+        ts.add_source(id, src)
+    tile_set = ts
+
+func _generate_map() -> void:
+    for q in range(-RADIUS, RADIUS + 1):
+        var r1 := max(-RADIUS, -q - RADIUS)
+        var r2 := min(RADIUS, -q + RADIUS)
+        for r in range(r1, r2 + 1):
+            var terrain := _pick_terrain()
+            var coords := Vector2i(q, r)
+            GameState.tiles[coords] = {"q": q, "r": r, "terrain": terrain}
+            set_cell(0, coords, TERRAIN_IDS[terrain])
+
+func _pick_terrain() -> String:
+    var roll := randf()
+    var cumulative := 0.0
+    for terrain in TERRAIN_WEIGHTS.keys():
+        cumulative += TERRAIN_WEIGHTS[terrain]
+        if roll <= cumulative:
+            return terrain
+    return "forest"

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -7,7 +7,7 @@ var tile_occupants: Dictionary = {}
 
 @onready var hud: CanvasLayer = $Hud
 @onready var game_clock: Node = $GameClock
-@onready var tile_map: TileMap = $LaneTileMap
+@onready var tile_map: TileMap = $HexMap
 
 
 func _ready() -> void:
@@ -19,10 +19,13 @@ func _ready() -> void:
 
 
 func _unhandled_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
-		var pos: Vector2 = tile_map.to_local(event.position)
-		selected_tile = tile_map.local_to_map(pos)
-		hud.update_tile(selected_tile, tile_occupants.get(selected_tile))
+        if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+                var pos: Vector2 = tile_map.to_local(event.position)
+                selected_tile = tile_map.local_to_map(pos)
+                var tile_data = GameState.tiles.get(selected_tile)
+                if tile_data:
+                        print("%d,%d,%s" % [selected_tile.x, selected_tile.y, tile_data.get("terrain", "")])
+                hud.update_tile(selected_tile, tile_occupants.get(selected_tile))
 	elif event is InputEventKey and event.pressed and event.keycode == KEY_B:
 		construct_building(FARM_BUILDING, selected_tile)
 


### PR DESCRIPTION
## Summary
- add tiles dictionary with save/load to GameState
- implement HexMap TileMap generating radius 8 hex terrain
- wire HexMap into World and log clicked terrain

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c06bf205d88330b9783115c095944a