### PR TITLE
Add selectable building types and HUD build controls

### DIFF
--- a/resources/buildings/barracks.tres
+++ b/resources/buildings/barracks.tres
@@ -1,0 +1,5 @@
+[gd_resource type="Resource" script="res://scripts/core/Building.gd"]
+[resource]
+name = "Barracks"
+construction_cost = {"gold": 150, "wood": 100}
+production_rates = {"sisu": 2}

--- a/resources/buildings/mine.tres
+++ b/resources/buildings/mine.tres
@@ -1,0 +1,5 @@
+[gd_resource type="Resource" script="res://scripts/core/Building.gd"]
+[resource]
+name = "Mine"
+construction_cost = {"gold": 100, "wood": 50}
+production_rates = {"gold": 10}

--- a/scenes/ui/Hud.tscn
+++ b/scenes/ui/Hud.tscn
@@ -27,3 +27,8 @@ text = "Trigger Event"
 
 [node name="EventLabel" type="Label" parent="."]
 text = "No events"
+
+[node name="BuildButton" type="Button" parent="."]
+text = "Build"
+
+[node name="BuildingSelector" type="OptionButton" parent="."]

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -2,6 +2,8 @@ extends CanvasLayer
 
 signal start_pressed
 signal pause_pressed
+signal build_pressed
+signal building_selected
 
 @onready var resources_label: Label = $ResourcesLabel
 @onready var tile_info_label: Label = $TileInfoLabel
@@ -11,23 +13,28 @@ signal pause_pressed
 @onready var policy_button: Button = $PolicyButton
 @onready var event_button: Button = $EventButton
 @onready var event_label: Label = $EventLabel
-
+@onready var build_button: Button = $BuildButton
+@onready var building_selector: OptionButton = $BuildingSelector
 
 func _ready() -> void:
 	start_button.pressed.connect(func(): start_pressed.emit())
 	pause_button.pressed.connect(func(): pause_pressed.emit())
 	policy_button.pressed.connect(_on_policy_pressed)
 	event_button.pressed.connect(_on_event_pressed)
-
+	build_button.pressed.connect(func(): build_pressed.emit())
+	for name in ["Farm", "Mine", "Barracks"]:
+		building_selector.add_item(name)
+	building_selector.item_selected.connect(_on_building_selected)
+	building_selector.select(0)
+	building_selected.emit(building_selector.get_item_text(0))
 
 func update_resources(resources: Dictionary) -> void:
-        var keys := resources.keys()
-        keys.sort()
-        var parts: PackedStringArray = []
-        for key in keys:
-                parts.append("%s: %d" % [key.capitalize(), int(resources[key])])
-        resources_label.text = " ".join(parts)
-
+	var keys := resources.keys()
+	keys.sort()
+	var parts: PackedStringArray = []
+	for key in keys:
+		parts.append("%s: %d" % [key.capitalize(), int(resources[key])])
+	resources_label.text = " ".join(parts)
 
 func update_tile(tile_pos: Vector2i, building: Building) -> void:
 	var text := "Tile: (%d,%d)" % [tile_pos.x, tile_pos.y]
@@ -37,10 +44,8 @@ func update_tile(tile_pos: Vector2i, building: Building) -> void:
 		text += " - Empty"
 	tile_info_label.text = text
 
-
 func update_clock(time: float) -> void:
 	clock_label.text = "Time: %.2f" % time
-
 
 func _on_policy_pressed() -> void:
 	var policy: Policy = load("res://resources/policies/tax_relief.tres")
@@ -54,3 +59,6 @@ func _on_event_pressed() -> void:
 		event_label.text = "%s occurred!" % ev.name
 	else:
 		event_label.text = "%s on cooldown" % ev.name
+
+func _on_building_selected(index: int) -> void:
+	building_selected.emit(building_selector.get_item_text(index))

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -1,6 +1,12 @@
 extends Node2D
 
-const FARM_BUILDING: Resource = preload("res://resources/buildings/farm.tres")
+const BUILDINGS := {
+	"Farm": preload("res://resources/buildings/farm.tres"),
+	"Mine": preload("res://resources/buildings/mine.tres"),
+	"Barracks": preload("res://resources/buildings/barracks.tres"),
+}
+
+var selected_building: Resource = BUILDINGS["Farm"]
 
 var selected_tile: Vector2i = Vector2i.ZERO
 var tile_occupants: Dictionary = {}
@@ -13,6 +19,8 @@ var hex_tiles: Dictionary = {}
 func _ready() -> void:
 	hud.start_pressed.connect(game_clock.start)
 	hud.pause_pressed.connect(game_clock.stop)
+	hud.building_selected.connect(_on_building_selected)
+	hud.build_pressed.connect(_on_build_pressed)
 	game_clock.tick.connect(_on_tick)
 	for hex in map_generator.get_children():
 		hex_tiles[Vector2i(hex.q, hex.r)] = hex
@@ -25,7 +33,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		selected_tile = map_generator.world_to_axial(pos)
 		hud.update_tile(selected_tile, tile_occupants.get(selected_tile))
 	elif event is InputEventKey and event.pressed and event.keycode == KEY_B:
-		construct_building(FARM_BUILDING, selected_tile)
+		construct_building(selected_building, selected_tile)
 
 func construct_building(building_res: Resource, tile_pos: Vector2i) -> void:
 	if tile_occupants.has(tile_pos) or !hex_tiles.has(tile_pos):
@@ -46,3 +54,9 @@ func _on_tick(time: float) -> void:
 			)
 	hud.update_resources(GameState.res)
 	hud.update_clock(time)
+
+func _on_building_selected(name: String) -> void:
+	selected_building = BUILDINGS.get(name, BUILDINGS["Farm"])
+
+func _on_build_pressed() -> void:
+	construct_building(selected_building, selected_tile)


### PR DESCRIPTION
## Summary
- add Mine and Barracks building resources
- let HUD select building type and trigger construction
- update World to build selected resource type via HUD or keypress

## Testing
- `/tmp/godot4/Godot_v4.2.1-stable_linux.x86_64 --headless -s tests/test_runner.gd`

------
https://chatgpt.com/codex/tasks/task_e_68c06ea4fea48330bcd6331a4b88489c