### PR TITLE
feat: add GameState autoload with offline resource gains

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -1,17 +1,18 @@
 extends Node
 
+const WOOD_PER_TICK := 0.2
+const FOOD_PER_TICK := 0.1
+const STEAM_PER_TICK := 0.2
+
 var res := {
-    "gold": 100.0,
-    "wood": 100.0,
+    "wood": 0.0,
     "food": 0.0,
+    "ore": 0.0,
     "research": 0.0,
     "influence": 0.0,
+    "steam": 0.0,
     "sisu": 0.0,
     "morale": 100.0,
-}
-
-var meta := {
-    "production_mult": 1.0,
 }
 
 var last_timestamp: int = 0
@@ -19,13 +20,18 @@ var last_timestamp: int = 0
 const SAVE_PATH := "user://save.json"
 
 func _ready() -> void:
-    load_state()
+    load()
+    GameClock.tick.connect(_on_tick)
+
+func _on_tick() -> void:
+    res["wood"] += WOOD_PER_TICK
+    res["food"] += FOOD_PER_TICK
+    res["steam"] += STEAM_PER_TICK
 
 func save() -> void:
     last_timestamp = Time.get_unix_time_from_system()
     var data := {
         "res": res,
-        "meta": meta,
         "last_timestamp": last_timestamp,
     }
     var file := FileAccess.open(SAVE_PATH, FileAccess.WRITE)
@@ -33,7 +39,7 @@ func save() -> void:
         file.store_string(JSON.stringify(data))
         file.close()
 
-func load_state() -> void:
+func load() -> void:
     if not FileAccess.file_exists(SAVE_PATH):
         last_timestamp = Time.get_unix_time_from_system()
         return
@@ -48,5 +54,16 @@ func load_state() -> void:
         last_timestamp = Time.get_unix_time_from_system()
         return
     res = data.get("res", res)
-    meta = data.get("meta", meta)
     last_timestamp = int(data.get("last_timestamp", Time.get_unix_time_from_system()))
+
+    var now := Time.get_unix_time_from_system()
+    var elapsed := now - last_timestamp
+    if elapsed > 0:
+        var ticks := int(elapsed / GameClock.TICK_INTERVAL)
+        if ticks > 0:
+            res["wood"] += WOOD_PER_TICK * ticks
+            res["food"] += FOOD_PER_TICK * ticks
+            res["steam"] += STEAM_PER_TICK * ticks
+    last_timestamp = now
+    save()
+

--- a/tests/test_game_state.gd
+++ b/tests/test_game_state.gd
@@ -1,0 +1,35 @@
+extends Node
+
+func _remove_save() -> void:
+    if FileAccess.file_exists(GameState.SAVE_PATH):
+        DirAccess.remove_absolute(GameState.SAVE_PATH)
+
+func test_save_creates_file(res) -> void:
+    GameClock.enabled = false
+    _remove_save()
+    GameState.save()
+    if not FileAccess.file_exists(GameState.SAVE_PATH):
+        res.fail("save file missing")
+
+func test_offline_gain(res) -> void:
+    GameClock.enabled = false
+    _remove_save()
+
+    var data := {
+        "res": GameState.res,
+        "last_timestamp": Time.get_unix_time_from_system() - 5,
+    }
+    var file := FileAccess.open(GameState.SAVE_PATH, FileAccess.WRITE)
+    file.store_string(JSON.stringify(data))
+    file.close()
+
+    GameState.res["wood"] = 0.0
+    GameState.res["food"] = 0.0
+    GameState.res["steam"] = 0.0
+    GameState.load()
+
+    var expected_ticks := int(5 / GameClock.TICK_INTERVAL)
+    var expected := GameState.WOOD_PER_TICK * expected_ticks
+    if GameState.res["wood"] < expected - 0.001:
+        res.fail("offline gains not applied")
+

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -11,6 +11,7 @@ var test_scripts := [
     preload("res://tests/test_rng.gd"),
     preload("res://tests/test_game_clock.gd"),
     preload("res://tests/test_building.gd"),
+    preload("res://tests/test_game_state.gd"),
 ]
 
 func _init() -> void:


### PR DESCRIPTION
## Summary
- add GameState autoload tracking resources, saving to JSON, and granting offline gains
- wire GameState to GameClock tick and introduce minimal economy
- cover save file creation and offline gain logic with tests

## Testing
- `godot3-server --headless -s res://tests/test_runner.gd` *(fails: Can't open project ... expected config version: 4)*


------
https://chatgpt.com/codex/tasks/task_e_68c0743ffca083308b1d9dd77bb80e12