### PR TITLE
chore: set main scene and document run steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Vertical slice WIP: 3 buildings, 3 units, 3 lanes, 1 neighbor AI, prestige stub,
 2. Press ▶ to run
 3. Exports via export_presets.cfg (to be added)
 
+## Runbook
+Open the project in Godot 4.x (Standard). In Project Settings, confirm the Main Scene is `scenes/ui/Main.tscn` and AutoLoads include `GameClock` (`res://autoload/GameClock.gd`) and `GameState` (`res://autoload/GameState.gd`). Press ▶ to run, then use the Save/Load demo to test persistence.
+
 ## Testing
 Run automated tests in headless mode:
 

--- a/project.godot
+++ b/project.godot
@@ -3,7 +3,7 @@ config_version=5
 
 [application]
 config/name="finsim_aa-club"
-run/main_scene="res://scenes/world/World.tscn"
+run/main_scene="res://scenes/ui/Main.tscn"
 config/features=PackedStringArray("4.0")
 
 [autoload]

--- a/scenes/ui/Main.tscn
+++ b/scenes/ui/Main.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2]
+
+[ext_resource path="res://scenes/ui/Hud.tscn" type="PackedScene" id="1"]
+
+[node name="Main" type="Node"]
+
+[node name="Hud" parent="." instance=ExtResource("1")]
+


### PR DESCRIPTION
## Summary
- set project main scene to new UI entry point
- document run steps in README

## Runbook
Open the project in Godot 4.x (Standard). In Project Settings, confirm the Main Scene is `scenes/ui/Main.tscn` and AutoLoads include `GameClock` (`res://autoload/GameClock.gd`) and `GameState` (`res://autoload/GameState.gd`). Press ▶ to run, then use the Save/Load demo to test persistence.

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0750511dc833088b783be8481de87