### PR TITLE
Add deterministic HexMap and Pathing tests

### DIFF
--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -1,0 +1,59 @@
+extends Node
+
+var HexMapBase = preload("res://scripts/world/HexMap.gd")
+
+class DummyHexMap extends HexMapBase:
+    func _init():
+        tile_set = TileSet.new()
+    func _set_tile(coord: Vector2i) -> void:
+        pass
+    func _setup_tileset() -> void:
+        pass
+
+func _reset_tiles() -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    gs.tiles.clear()
+
+func test_generate_tiles(res) -> void:
+    _reset_tiles()
+    var map = DummyHexMap.new()
+    map.radius = 2
+    map.terrain_weights = {"forest": 1.0}
+    map._generate_tiles()
+    var gs = Engine.get_main_loop().root.get_node("GameState")
+    if gs.tiles.size() != 19:
+        res.fail("Expected 19 tiles, got %d" % gs.tiles.size())
+    else:
+        for t in gs.tiles.values():
+            if t.get("terrain") != "forest":
+                res.fail("Unexpected terrain %s" % t.get("terrain"))
+                break
+
+func test_reveal_area(res) -> void:
+    _reset_tiles()
+    var map = DummyHexMap.new()
+    map.radius = 2
+    map.terrain_weights = {"forest": 1.0}
+    map._generate_tiles()
+    map.reveal_area(Vector2i.ZERO, 1)
+    var gs = Engine.get_main_loop().root.get_node("GameState")
+    var explored: Array[Vector2i] = []
+    for coord in gs.tiles.keys():
+        if gs.tiles[coord]["explored"]:
+            explored.append(coord)
+    var expected := [
+        Vector2i(0,0), Vector2i(1,0), Vector2i(1,-1),
+        Vector2i(0,-1), Vector2i(-1,0), Vector2i(-1,1), Vector2i(0,1)
+    ]
+    if explored.size() != expected.size():
+        res.fail("Expected %d explored, got %d" % [expected.size(), explored.size()])
+    else:
+        for e in expected:
+            if e not in explored:
+                res.fail("Missing %s" % e)
+                break
+    for coord in gs.tiles.keys():
+        if coord not in expected and gs.tiles[coord]["explored"]:
+            res.fail("Tile %s explored outside radius" % coord)
+            break

--- a/tests/test_pathing.gd
+++ b/tests/test_pathing.gd
@@ -1,0 +1,19 @@
+extends Node
+
+var Pathing = preload("res://scripts/world/Pathing.gd")
+
+func test_bfs_path(res) -> void:
+    var start := Vector2i(0, 0)
+    var goal := Vector2i(2, 0)
+    var blocked := {Vector2i(1, 0): true}
+    var passable := func(cell: Vector2i) -> bool:
+        return !blocked.has(cell)
+    var path := Pathing.bfs_path(start, goal, passable)
+    var expected := [Vector2i(0,0), Vector2i(1,-1), Vector2i(2,-1), Vector2i(2,0)]
+    if path.size() != expected.size():
+        res.fail("Expected path length %d, got %d" % [expected.size(), path.size()])
+        return
+    for i in range(path.size()):
+        if path[i] != expected[i]:
+            res.fail("Mismatch at %d" % i)
+            break

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -12,6 +12,8 @@ var test_script_paths := [
     "res://tests/test_game_clock.gd",
     "res://tests/test_building.gd",
     "res://tests/test_game_state.gd",
+    "res://tests/test_hexmap.gd",
+    "res://tests/test_pathing.gd",
 ]
 
 func _init() -> void:


### PR DESCRIPTION
## Summary
- add HexMap tests for tile generation and reveal radius
- add Pathing test for BFS path around obstacles
- register new tests in test runner

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c13bedf15c8330a2159987fc041006