### PR TITLE
Persist unit stats across save/load

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -41,6 +41,10 @@ func save() -> void:
         unit_data.append({
             "type": u.get("type", ""),
             "pos_qr": [u.get("pos_qr", Vector2i.ZERO).x, u.get("pos_qr", Vector2i.ZERO).y],
+            "hp": u.get("hp", 0),
+            "atk": u.get("atk", 0),
+            "def": u.get("def", 0),
+            "move": u.get("move", 0),
         })
     var data := {
         "res": res,
@@ -82,6 +86,10 @@ func load_state() -> void:
         units.append({
             "type": u.get("type", ""),
             "pos_qr": Vector2i(int(pos_arr[0]), int(pos_arr[1])),
+            "hp": int(u.get("hp", 0)),
+            "atk": int(u.get("atk", 0)),
+            "def": int(u.get("def", 0)),
+            "move": int(u.get("move", 0)),
         })
 
     var now := Time.get_unix_time_from_system()

--- a/scripts/units/Unit.gd
+++ b/scripts/units/Unit.gd
@@ -1,8 +1,26 @@
 extends Node2D
 
 @export var type := "conscript"
-var hp := 100
-var atk := 10
-var def := 1
-var move := 1
+@export var hp := 100
+@export var atk := 10
+@export var def := 1
+@export var move := 1
 var pos_qr := Vector2i.ZERO
+
+func to_dict() -> Dictionary:
+    return {
+        "type": type,
+        "pos_qr": pos_qr,
+        "hp": hp,
+        "atk": atk,
+        "def": def,
+        "move": move,
+    }
+
+func from_dict(data: Dictionary) -> void:
+    type = data.get("type", type)
+    pos_qr = data.get("pos_qr", pos_qr)
+    hp = data.get("hp", hp)
+    atk = data.get("atk", atk)
+    def = data.get("def", def)
+    move = data.get("move", move)

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -12,8 +12,7 @@ func _ready() -> void:
     hex_map.tile_clicked.connect(_on_tile_clicked)
     for data in GameState.units:
         var u = unit_scene.instantiate()
-        u.type = data.get("type", "conscript")
-        u.pos_qr = data.get("pos_qr", Vector2i.ZERO)
+        u.from_dict(data)
         u.position = hex_map.axial_to_world(u.pos_qr)
         units_root.add_child(u)
         selected_unit = u
@@ -28,9 +27,10 @@ func _on_tile_clicked(qr: Vector2i) -> void:
             var next := path[1]
             selected_unit.pos_qr = next
             selected_unit.position = hex_map.axial_to_world(next)
-            for u in GameState.units:
+            for i in range(GameState.units.size()):
+                var u = GameState.units[i]
                 if u.get("type", "") == selected_unit.type:
-                    u["pos_qr"] = next
+                    GameState.units[i] = selected_unit.to_dict()
                     break
             hex_map.reveal_area(next, 1)
             GameState.save()
@@ -40,7 +40,7 @@ func spawn_unit_at_center() -> void:
     units_root.add_child(u)
     u.pos_qr = Vector2i.ZERO
     u.position = hex_map.axial_to_world(u.pos_qr)
-    GameState.units.append({"type": u.type, "pos_qr": u.pos_qr})
+    GameState.units.append(u.to_dict())
     selected_unit = u
     hex_map.reveal_area(u.pos_qr, 1)
     GameState.save()

--- a/tests/test_game_state.gd
+++ b/tests/test_game_state.gd
@@ -39,3 +39,31 @@ func test_offline_gain(res) -> void:
     if gs.res["wood"] < expected - 0.001:
         res.fail("offline gains not applied")
 
+func test_unit_stats_persist(res) -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    var clock = tree.root.get_node("GameClock")
+    clock.set_process(false)
+    _remove_save(gs)
+
+    gs.units.clear()
+    gs.units.append({
+        "type": "conscript",
+        "pos_qr": Vector2i(1, 2),
+        "hp": 55,
+        "atk": 6,
+        "def": 3,
+        "move": 4,
+    })
+    gs.save()
+
+    gs.units.clear()
+    gs.load()
+
+    if gs.units.size() != 1:
+        res.fail("unit not loaded")
+        return
+    var u = gs.units[0]
+    if u.get("hp", 0) != 55 or u.get("atk", 0) != 6 or u.get("def", 0) != 3 or u.get("move", 0) != 4:
+        res.fail("unit stats not preserved")
+


### PR DESCRIPTION
## Summary
- Save and load unit combat stats in GameState
- Sync World unit spawning and saving with full stats
- Add helper methods on Unit for serialization
- Ensure unit stats survive a save/load cycle

## Testing
- `godot3-server --headless --path . -s tests/test_runner.gd` *(fails: project requires newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c13bf6981c8330b8b71c8b4bf59088