### PR TITLE
Prevent terrain regen when tiles exist

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -14,9 +14,9 @@ func _ready() -> void:
     _setup_tileset()
     if GameState.tiles.is_empty():
         _generate_tiles()
+        reveal_area(Vector2i.ZERO, 2)
     else:
         _load_tiles()
-    reveal_area(Vector2i.ZERO, 2)
 
 func _setup_tileset() -> void:
     if tile_set == null:

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -30,6 +30,15 @@ func test_generate_tiles(res) -> void:
                 res.fail("Unexpected terrain %s" % t.get("terrain"))
                 break
 
+func test_ready_uses_saved_tiles(res) -> void:
+    _reset_tiles()
+    var gs = Engine.get_main_loop().root.get_node("GameState")
+    gs.tiles[Vector2i(0,0)] = {"terrain": "forest", "owner": "none", "building": null, "explored": false}
+    var map = DummyHexMap.new()
+    map._ready()
+    if gs.tiles.size() != 1 or not gs.tiles.has(Vector2i(0,0)):
+        res.fail("Expected existing tiles to persist after _ready")
+
 func test_reveal_area(res) -> void:
     _reset_tiles()
     var map = DummyHexMap.new()


### PR DESCRIPTION
## Summary
- Don't regenerate terrain in `HexMap._ready` when tiles are already loaded
- Add test to ensure `_ready` uses saved tiles instead of generating new ones

## Testing
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `apt-get install -y godot` *(fails: Unable to locate package godot)*
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c148ae6d7883309516c07199834029