### PR TITLE
GFX-T1: add placeholder tiles and tokens

### DIFF
--- a/assets/tiles/forest.svg
+++ b/assets/tiles/forest.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="84" viewBox="0 0 96 84">
+  <polygon points="48,0 96,21 96,63 48,84 0,63 0,21" fill="#228B22"/>
+</svg>

--- a/assets/tiles/hill.svg
+++ b/assets/tiles/hill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="84" viewBox="0 0 96 84">
+  <polygon points="48,0 96,21 96,63 48,84 0,63 0,21" fill="#8B4513"/>
+</svg>

--- a/assets/tiles/lake.svg
+++ b/assets/tiles/lake.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="84" viewBox="0 0 96 84">
+  <polygon points="48,0 96,21 96,63 48,84 0,63 0,21" fill="#1E90FF"/>
+</svg>

--- a/assets/tiles/ruins.svg
+++ b/assets/tiles/ruins.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="84" viewBox="0 0 96 84">
+  <polygon points="48,0 96,21 96,63 48,84 0,63 0,21" fill="#696969"/>
+</svg>

--- a/assets/tiles/taiga.svg
+++ b/assets/tiles/taiga.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="84" viewBox="0 0 96 84">
+  <polygon points="48,0 96,21 96,63 48,84 0,63 0,21" fill="#006400"/>
+</svg>

--- a/assets/tiles/town.svg
+++ b/assets/tiles/town.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="84" viewBox="0 0 96 84">
+  <polygon points="48,0 96,21 96,63 48,84 0,63 0,21" fill="#C0C0C0"/>
+</svg>

--- a/assets/tokens/conscript.svg
+++ b/assets/tokens/conscript.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#cccccc"/>
+  <path d="M22 6 A10 10 0 1 0 22 26" stroke="#000" stroke-width="4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/assets/tokens/jaeger.svg
+++ b/assets/tokens/jaeger.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#98fb98"/>
+  <path d="M16 6 H24 M24 6 L24 22 A8 8 0 0 1 8 22" stroke="#000" stroke-width="4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/assets/tokens/settler.svg
+++ b/assets/tokens/settler.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#f0e68c"/>
+  <path d="M22 6 A10 10 0 0 0 10 16 A10 10 0 0 1 22 26" stroke="#000" stroke-width="4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/assets/tokens/ski.svg
+++ b/assets/tokens/ski.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#add8e6"/>
+  <path d="M8 8 L24 24 M24 8 L8 24" stroke="#000" stroke-width="4" fill="none" stroke-linecap="round"/>
+</svg>

--- a/resources/TileSet.tres
+++ b/resources/TileSet.tres
@@ -1,0 +1,49 @@
+[gd_resource type="TileSet" load_steps=13 format=3]
+
+[ext_resource path="res://assets/tiles/forest.svg" type="Texture2D" id="1"]
+[ext_resource path="res://assets/tiles/taiga.svg" type="Texture2D" id="2"]
+[ext_resource path="res://assets/tiles/hill.svg" type="Texture2D" id="3"]
+[ext_resource path="res://assets/tiles/lake.svg" type="Texture2D" id="4"]
+[ext_resource path="res://assets/tiles/town.svg" type="Texture2D" id="5"]
+[ext_resource path="res://assets/tiles/ruins.svg" type="Texture2D" id="6"]
+
+[sub_resource type="TileSetAtlasSource" id="1"]
+texture = ExtResource("1")
+texture_region_size = Vector2i(96, 84)
+0:0/0 = 0
+
+[sub_resource type="TileSetAtlasSource" id="2"]
+texture = ExtResource("2")
+texture_region_size = Vector2i(96, 84)
+0:0/0 = 0
+
+[sub_resource type="TileSetAtlasSource" id="3"]
+texture = ExtResource("3")
+texture_region_size = Vector2i(96, 84)
+0:0/0 = 0
+
+[sub_resource type="TileSetAtlasSource" id="4"]
+texture = ExtResource("4")
+texture_region_size = Vector2i(96, 84)
+0:0/0 = 0
+
+[sub_resource type="TileSetAtlasSource" id="5"]
+texture = ExtResource("5")
+texture_region_size = Vector2i(96, 84)
+0:0/0 = 0
+
+[sub_resource type="TileSetAtlasSource" id="6"]
+texture = ExtResource("6")
+texture_region_size = Vector2i(96, 84)
+0:0/0 = 0
+
+[resource]
+tile_shape = 3
+tile_offset_axis = 1
+tile_size = Vector2i(96, 84)
+sources/0 = SubResource("1")
+sources/1 = SubResource("2")
+sources/2 = SubResource("3")
+sources/3 = SubResource("4")
+sources/4 = SubResource("5")
+sources/5 = SubResource("6")

--- a/scenes/world/HexMap.tscn
+++ b/scenes/world/HexMap.tscn
@@ -1,7 +1,10 @@
-[gd_scene load_steps=2]
+[gd_scene load_steps=3]
 
 [ext_resource path="res://scripts/world/HexMap.gd" type="Script" id="1"]
+[ext_resource path="res://resources/TileSet.tres" type="TileSet" id="2"]
 
 [node name="HexMap" type="TileMap"]
 layers = 2
+tile_set = ExtResource("2")
+cell_tile_size = Vector2i(96, 84)
 script = ExtResource("1")


### PR DESCRIPTION
## Summary
- add flat-color SVG hex tiles and unit token glyphs
- configure TileSet and HexMap for hex pointy layout

## Testing
- `godot3 --headless --quiet -s tests/test_runner.gd` *(fails: project config_version 5 is newer than engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c14ac8cd74833086aaa7f237767eb1