### PR TITLE
Auto-populate UI resource selectors

### DIFF
--- a/scenes/ui/Hud.tscn
+++ b/scenes/ui/Hud.tscn
@@ -22,8 +22,12 @@ text = "Time: 0"
 [node name="PolicyButton" type="Button" parent="."]
 text = "Use Policy"
 
+[node name="PolicySelector" type="OptionButton" parent="."]
+
 [node name="EventButton" type="Button" parent="."]
 text = "Trigger Event"
+
+[node name="EventSelector" type="OptionButton" parent="."]
 
 [node name="EventLabel" type="Label" parent="."]
 text = "No events"

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -15,6 +15,11 @@ signal building_selected
 @onready var event_label: Label = $EventLabel
 @onready var build_button: Button = $BuildButton
 @onready var building_selector: OptionButton = $BuildingSelector
+@onready var policy_selector: OptionButton = $PolicySelector
+@onready var event_selector: OptionButton = $EventSelector
+
+var _policies: Array[Policy] = []
+var _events: Array[GameEvent] = []
 
 const Building = preload("res://scripts/core/Building.gd")
 const Policy = preload("res://scripts/policies/Policy.gd")
@@ -26,11 +31,17 @@ func _ready() -> void:
     policy_button.pressed.connect(_on_policy_pressed)
     event_button.pressed.connect(_on_event_pressed)
     build_button.pressed.connect(func(): build_pressed.emit())
-    for name in ["Farm", "Mine", "Barracks"]:
-        building_selector.add_item(name)
+    _populate_buildings()
+    _populate_policies()
+    _populate_events()
     building_selector.item_selected.connect(_on_building_selected)
-    building_selector.select(0)
-    building_selected.emit(building_selector.get_item_text(0))
+    if building_selector.item_count > 0:
+        building_selector.select(0)
+        building_selected.emit(building_selector.get_item_text(0))
+    if policy_selector.item_count > 0:
+        policy_selector.select(0)
+    if event_selector.item_count > 0:
+        event_selector.select(0)
 
 func update_resources(resources: Dictionary) -> void:
     var keys := resources.keys()
@@ -52,17 +63,45 @@ func update_clock(time: float) -> void:
     clock_label.text = "Time: %.2f" % time
 
 func _on_policy_pressed() -> void:
-    var policy: Policy = load("res://resources/policies/tax_relief.tres")
-    if policy.apply():
-        update_resources(GameState.res)
+    var idx := policy_selector.get_selected()
+    if idx >= 0 and idx < _policies.size():
+        var policy: Policy = _policies[idx]
+        if policy.apply():
+            update_resources(GameState.res)
 
 func _on_event_pressed() -> void:
-    var ev: GameEvent = load("res://resources/events/rain.tres")
-    if ev.apply():
-        update_resources(GameState.res)
-        event_label.text = "%s occurred!" % ev.name
-    else:
-        event_label.text = "%s on cooldown" % ev.name
+    var idx := event_selector.get_selected()
+    if idx >= 0 and idx < _events.size():
+        var ev: GameEvent = _events[idx]
+        if ev.apply():
+            update_resources(GameState.res)
+            event_label.text = "%s occurred!" % ev.name
+        else:
+            event_label.text = "%s on cooldown" % ev.name
 
 func _on_building_selected(index: int) -> void:
     building_selected.emit(building_selector.get_item_text(index))
+
+func _populate_buildings() -> void:
+    for file in DirAccess.get_files_at("res://resources/buildings"):
+        if file.get_extension() == "tres":
+            var b: Building = load("res://resources/buildings/%s" % file)
+            building_selector.add_item(b.name)
+
+func _populate_policies() -> void:
+    _policies.clear()
+    policy_selector.clear()
+    for file in DirAccess.get_files_at("res://resources/policies"):
+        if file.get_extension() == "tres":
+            var p: Policy = load("res://resources/policies/%s" % file)
+            policy_selector.add_item(p.name)
+            _policies.append(p)
+
+func _populate_events() -> void:
+    _events.clear()
+    event_selector.clear()
+    for file in DirAccess.get_files_at("res://resources/events"):
+        if file.get_extension() == "tres":
+            var e: GameEvent = load("res://resources/events/%s" % file)
+            event_selector.add_item(e.name)
+            _events.append(e)


### PR DESCRIPTION
## Summary
- Build UI dropdowns by scanning `resources/buildings` at runtime
- Populate policy and event selectors from their resource directories
- Apply selected policies and events without hard-coded paths

## Testing
- `godot3-runner -s tests/test_runner.gd` *(fails: Can't open project, requires newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68c1519cf0b88330b4ec498d0aa21832