### PR TITLE
GFX-T4: paper grain overlay and UI theme

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -10,3 +10,6 @@ config/features=PackedStringArray("4.0")
 GameState="*res://autoload/GameState.gd"
 GameClock="*res://autoload/GameClock.gd"
 RNG="*res://autoload/RNG.gd"
+
+[gui]
+theme/custom="res://resources/Theme.tres"

--- a/resources/GrainNoise.tres
+++ b/resources/GrainNoise.tres
@@ -1,0 +1,13 @@
+[gd_resource type="NoiseTexture2D" load_steps=2 format=3]
+
+[sub_resource type="OpenSimplexNoise" id="1"]
+octaves = 4
+period = 32.0
+persistence = 0.8
+
+[resource]
+width = 1024
+height = 1024
+seamless = true
+noise = SubResource("1")
+

--- a/resources/Theme.tres
+++ b/resources/Theme.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Theme" load_steps=2 format=3]
+
+[sub_resource type="StyleBoxFlat" id="1"]
+bg_color = Color(1,1,1,1)
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_left = 12
+corner_radius_bottom_right = 12
+content_margin_left = 8
+content_margin_right = 8
+content_margin_top = 4
+content_margin_bottom = 4
+
+[resource]
+Button/styles/normal = SubResource("1")
+Button/styles/hover = SubResource("1")
+Button/styles/pressed = SubResource("1")
+Button/styles/focus = SubResource("1")
+Button/styles/disabled = SubResource("1")

--- a/scenes/ui/Main.tscn
+++ b/scenes/ui/Main.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=4]
+[gd_scene load_steps=5]
 
 [ext_resource path="res://scenes/ui/Hud.tscn" type="PackedScene" id="1"]
 [ext_resource path="res://scenes/world/World.tscn" type="PackedScene" id="2"]
 [ext_resource path="res://scripts/ui/Main.gd" type="Script" id="3"]
+
+[ext_resource path="res://resources/GrainNoise.tres" type="Texture2D" id="4"]
 
 [node name="Main" type="Node"]
 script = ExtResource("3")
@@ -10,6 +12,22 @@ script = ExtResource("3")
 [node name="World" parent="." instance=ExtResource("2")]
 
 [node name="Hud" parent="." instance=ExtResource("1")]
+
+[node name="GrainOverlay" type="CanvasLayer" parent="."]
+layer = 1
+
+[node name="Grain" type="ColorRect" parent="GrainOverlay"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+texture = ExtResource("4")
+texture_repeat = 2
+blend_mode = 3
+modulate = Color(1,1,1,0.07)
+mouse_filter = 2
 
 [node name="DebugUI" type="Control" parent="."]
 


### PR DESCRIPTION
## Summary
- Replace birch paper texture with procedural noise grain overlay at 7% multiply blend.
- Drop bundled font to rely on engine default while retaining 12 px rounded button style.

## Testing
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `apt-get install -y godot` *(fails: Unable to locate package godot)*
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c14fafa0288330af32cea81dc0e051