### PR TITLE
Use UnitData resource for unit stats

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -40,11 +40,9 @@ func save() -> void:
     for u in units:
         unit_data.append({
             "type": u.get("type", ""),
+            "data_path": u.get("data_path", ""),
             "pos_qr": [u.get("pos_qr", Vector2i.ZERO).x, u.get("pos_qr", Vector2i.ZERO).y],
             "hp": u.get("hp", 0),
-            "atk": u.get("atk", 0),
-            "def": u.get("def", 0),
-            "move": u.get("move", 0),
         })
     var data := {
         "res": res,
@@ -85,11 +83,9 @@ func load_state() -> void:
         var pos_arr: Array = u.get("pos_qr", [0, 0])
         units.append({
             "type": u.get("type", ""),
+            "data_path": u.get("data_path", ""),
             "pos_qr": Vector2i(int(pos_arr[0]), int(pos_arr[1])),
             "hp": int(u.get("hp", 0)),
-            "atk": int(u.get("atk", 0)),
-            "def": int(u.get("def", 0)),
-            "move": int(u.get("move", 0)),
         })
 
     var now := Time.get_unix_time_from_system()

--- a/resources/units/footman.tres
+++ b/resources/units/footman.tres
@@ -1,6 +1,8 @@
-[gd_resource type="Resource" script="res://scripts/units/Unit.gd"]
+[gd_resource type="Resource" load_steps=2]
+[ext_resource path="res://scripts/units/UnitData.gd" type="Script" id=1]
 
 [resource]
+script = ExtResource("1")
 name = "Footman"
 max_health = 120
 attack = 20

--- a/scripts/units/Unit.gd
+++ b/scripts/units/Unit.gd
@@ -1,26 +1,46 @@
 extends Node2D
 
-@export var type := "conscript"
-@export var hp := 100
-@export var atk := 10
-@export var def := 1
-@export var move := 1
+const UnitData = preload("res://scripts/units/UnitData.gd")
+
+@export var unit_data: UnitData
+var type := "conscript"
+var hp := 100
+var atk := 10
+var def := 1
+var move := 1.0
 var pos_qr := Vector2i.ZERO
+
+func _ready() -> void:
+    if unit_data:
+        apply_data(unit_data)
+
+func apply_data(d: UnitData) -> void:
+    unit_data = d
+    if unit_data:
+        type = unit_data.name
+        hp = unit_data.max_health
+        atk = unit_data.attack
+        def = unit_data.defense
+        move = unit_data.speed
 
 func to_dict() -> Dictionary:
     return {
         "type": type,
+        "data_path": unit_data.resource_path if unit_data else "",
         "pos_qr": pos_qr,
         "hp": hp,
-        "atk": atk,
-        "def": def,
-        "move": move,
     }
 
 func from_dict(data: Dictionary) -> void:
-    type = data.get("type", type)
     pos_qr = data.get("pos_qr", pos_qr)
+    var path: String = data.get("data_path", "")
+    if path != "":
+        var ud: UnitData = load(path) as UnitData
+        if ud:
+            apply_data(ud)
     hp = data.get("hp", hp)
-    atk = data.get("atk", atk)
-    def = data.get("def", def)
-    move = data.get("move", move)
+    if unit_data == null:
+        type = data.get("type", type)
+        atk = data.get("atk", atk)
+        def = data.get("def", def)
+        move = data.get("move", move)

--- a/scripts/units/UnitData.gd
+++ b/scripts/units/UnitData.gd
@@ -1,0 +1,8 @@
+extends Resource
+class_name UnitData
+
+@export var name: String = ""
+@export var max_health: int = 0
+@export var attack: int = 0
+@export var defense: int = 0
+@export var speed: float = 0.0

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -38,6 +38,9 @@ func _on_tile_clicked(qr: Vector2i) -> void:
 
 func spawn_unit_at_center() -> void:
     var u: Node = unit_scene.instantiate()
+    var data_res: UnitData = load("res://resources/units/footman.tres")
+    if data_res:
+        u.apply_data(data_res)
     units_root.add_child(u)
     u.pos_qr = Vector2i.ZERO
     u.position = hex_map.axial_to_world(u.pos_qr)

--- a/tests/test_game_state.gd
+++ b/tests/test_game_state.gd
@@ -48,12 +48,10 @@ func test_unit_stats_persist(res) -> void:
 
     gs.units.clear()
     gs.units.append({
-        "type": "conscript",
+        "type": "Footman",
+        "data_path": "res://resources/units/footman.tres",
         "pos_qr": Vector2i(1, 2),
         "hp": 55,
-        "atk": 6,
-        "def": 3,
-        "move": 4,
     })
     gs.save()
 
@@ -63,7 +61,10 @@ func test_unit_stats_persist(res) -> void:
     if gs.units.size() != 1:
         res.fail("unit not loaded")
         return
-    var u = gs.units[0]
-    if u.get("hp", 0) != 55 or u.get("atk", 0) != 6 or u.get("def", 0) != 3 or u.get("move", 0) != 4:
+    var u_dict = gs.units[0]
+    var unit_scene: PackedScene = load("res://scenes/units/Unit.tscn")
+    var unit = unit_scene.instantiate()
+    unit.from_dict(u_dict)
+    if unit.hp != 55 or unit.atk != 20 or unit.def != 8 or abs(unit.move - 1.5) > 0.01:
         res.fail("unit stats not preserved")
 


### PR DESCRIPTION
## Summary
- Introduce `UnitData` resource to hold unit stat definitions
- Load unit stats from `UnitData` when spawning or restoring units
- Persist unit resource path and health in game state and update tests

## Testing
- `godot --headless --path . -s /tmp/test_runner_game_state.gd`
- `godot --headless --path . -s tests/test_runner.gd` *(fails: Could not resolve class "HexMap")*


------
https://chatgpt.com/codex/tasks/task_e_68c15192e8c883309bf38c7efff5cf08