### PR TITLE
refactor: centralize hex utilities and RNG

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -6,7 +6,7 @@ class_name HexMap
 
 signal tile_clicked(qr:Vector2i)
 
-const HEX_DIRS = [Vector2i(1,0), Vector2i(1,-1), Vector2i(0,-1), Vector2i(-1,0), Vector2i(-1,1), Vector2i(0,1)]
+const HexUtils = preload("res://scripts/world/HexUtils.gd")
 
 var _terrain_sources: Dictionary = {}
 var fog_map: TileMap = null
@@ -47,10 +47,9 @@ func _setup_tileset() -> void:
             _terrain_sources[names[i]] = ids[i]
 
 func _generate_tiles() -> void:
-    var rng := RandomNumberGenerator.new()
     for q in range(-radius, radius + 1):
         for r in range(max(-radius, -q - radius), min(radius, -q + radius) + 1):
-            var terrain := _random_terrain(rng)
+            var terrain := _random_terrain()
             GameState.tiles[Vector2i(q, r)] = {
                 "terrain": terrain,
                 "owner": "none",
@@ -74,8 +73,8 @@ func _set_tile(coord: Vector2i) -> void:
         else:
             fog_map.set_cell(0, coord, fog_map.source_id, Vector2i.ZERO)
 
-func _random_terrain(rng: RandomNumberGenerator) -> String:
-    var roll := rng.randf()
+func _random_terrain() -> String:
+    var roll := RNG.randf()
     var acc := 0.0
     for k in terrain_weights.keys():
         acc += terrain_weights[k]
@@ -94,7 +93,7 @@ func _unhandled_input(event: InputEvent) -> void:
 
 static func axial_neighbors(q: int, r: int) -> Array[Vector2i]:
     var res: Array[Vector2i] = []
-    for d in HEX_DIRS:
+    for d in HexUtils.HEX_DIRS:
         res.append(Vector2i(q + d.x, r + d.y))
     return res
 
@@ -118,7 +117,9 @@ func reveal_all() -> void:
             fog_map.set_cell(0, coord, -1, Vector2i.ZERO)
 
 func axial_to_world(qr: Vector2i) -> Vector2:
-    return to_global(map_to_local(qr))
+    var radius := tile_set.tile_size.x / 2.0
+    return HexUtils.axial_to_world(qr.x, qr.y, radius)
 
 func world_to_axial(pos: Vector2) -> Vector2i:
-    return local_to_map(to_local(pos))
+    var radius := tile_set.tile_size.x / 2.0
+    return HexUtils.world_to_axial(pos, radius)

--- a/scripts/world/HexUtils.gd
+++ b/scripts/world/HexUtils.gd
@@ -1,0 +1,23 @@
+extends Object
+class_name HexUtils
+
+const HEX_DIRS = [
+    Vector2i(1,0),
+    Vector2i(1,-1),
+    Vector2i(0,-1),
+    Vector2i(-1,0),
+    Vector2i(-1,1),
+    Vector2i(0,1),
+]
+
+const RNG = preload("res://autoload/RNG.gd")
+
+static func axial_to_world(q: int, r: int, hex_radius: float) -> Vector2:
+    var x := hex_radius * sqrt(3.0) * (q + r / 2.0)
+    var y := hex_radius * 1.5 * r
+    return Vector2(x, y)
+
+static func world_to_axial(pos: Vector2, hex_radius: float) -> Vector2i:
+    var q := (sqrt(3.0) / 3.0 * pos.x - pos.y / 3.0) / hex_radius
+    var r := (2.0 / 3.0 * pos.y) / hex_radius
+    return Vector2i(int(round(q)), int(round(r)))

--- a/scripts/world/MapGenerator.gd
+++ b/scripts/world/MapGenerator.gd
@@ -5,24 +5,14 @@ extends Node2D
 @export var seed: int = 0
 @export var hex_radius: float = 32.0
 
+const HexUtils = preload("res://scripts/world/HexUtils.gd")
 var noise := FastNoiseLite.new()
-var rng := RandomNumberGenerator.new()
 @onready var hex_tile_scene: PackedScene = preload("res://scenes/world/HexTile.tscn")
 
 func _ready() -> void:
     noise.seed = seed
-    rng.seed = seed
+    RNG.seed_from_string(str(seed))
     generate_map()
-
-func axial_to_world(q: int, r: int) -> Vector2:
-    var x := hex_radius * sqrt(3.0) * (q + r / 2.0)
-    var y := hex_radius * 1.5 * r
-    return Vector2(x, y)
-
-func world_to_axial(pos: Vector2) -> Vector2i:
-    var q := (sqrt(3.0) / 3.0 * pos.x - pos.y / 3.0) / hex_radius
-    var r := (2.0 / 3.0 * pos.y) / hex_radius
-    return Vector2i(int(round(q)), int(round(r)))
 
 func generate_map() -> void:
     for child in get_children():
@@ -37,7 +27,7 @@ func generate_map() -> void:
             elif noise_val > 0.0:
                 terrain_type = "grass"
             var resource_type := ""
-            var roll := rng.randf()
+            var roll := RNG.randf()
             if roll < 0.1:
                 resource_type = "gold"
             elif roll < 0.25:
@@ -46,5 +36,5 @@ func generate_map() -> void:
             hex.r = r
             hex.terrain = terrain_type
             hex.resource = resource_type
-            hex.position = axial_to_world(q, r)
+            hex.position = HexUtils.axial_to_world(q, r, hex_radius)
             add_child(hex)

--- a/scripts/world/Pathing.gd
+++ b/scripts/world/Pathing.gd
@@ -1,7 +1,6 @@
 extends Object
 class_name Pathing
-const HEX_DIRS = [Vector2i(1,0), Vector2i(1,-1), Vector2i(0,-1), Vector2i(-1,0), Vector2i(-1,1), Vector2i(0,1)]
-
+const HexUtils = preload("res://scripts/world/HexUtils.gd")
 const HexMap = preload("res://scripts/world/HexMap.gd")
 
 static func bfs_path(start: Vector2i, goal: Vector2i, passable: Callable) -> Array[Vector2i]:
@@ -13,7 +12,7 @@ static func bfs_path(start: Vector2i, goal: Vector2i, passable: Callable) -> Arr
         var current: Vector2i = frontier.pop_front()
         if current == goal:
             break
-        for dir in HEX_DIRS:
+        for dir in HexUtils.HEX_DIRS:
             var nxt: Vector2i = current + dir
             if !passable.call(nxt):
                 continue


### PR DESCRIPTION
## Summary
- add `HexUtils` with shared hex directions, conversion helpers, and RNG access
- refactor `HexMap`, `Pathing`, and `MapGenerator` to rely on `HexUtils`
- use global `RNG` autoload for deterministic seeding

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c151a444988330a75716a6a6eb7221