### PR TITLE
Persist unit identifiers

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -39,6 +39,7 @@ func save() -> void:
     var unit_data: Array = []
     for u in units:
         unit_data.append({
+            "id": u.get("id", ""),
             "type": u.get("type", ""),
             "data_path": u.get("data_path", ""),
             "pos_qr": [u.get("pos_qr", Vector2i.ZERO).x, u.get("pos_qr", Vector2i.ZERO).y],
@@ -81,7 +82,11 @@ func load_state() -> void:
     units.clear()
     for u in data.get("units", []):
         var pos_arr: Array = u.get("pos_qr", [0, 0])
+        var uid: String = u.get("id", "")
+        if uid == "":
+            uid = UUID.new_uuid_string()
         units.append({
+            "id": uid,
             "type": u.get("type", ""),
             "data_path": u.get("data_path", ""),
             "pos_qr": Vector2i(int(pos_arr[0]), int(pos_arr[1])),

--- a/scripts/units/Unit.gd
+++ b/scripts/units/Unit.gd
@@ -3,6 +3,7 @@ extends Node2D
 const UnitData = preload("res://scripts/units/UnitData.gd")
 
 @export var unit_data: UnitData
+var id: String = UUID.new_uuid_string()
 var type := "conscript"
 var hp := 100
 var atk := 10
@@ -25,6 +26,7 @@ func apply_data(d: UnitData) -> void:
 
 func to_dict() -> Dictionary:
     return {
+        "id": id,
         "type": type,
         "data_path": unit_data.resource_path if unit_data else "",
         "pos_qr": pos_qr,
@@ -32,6 +34,7 @@ func to_dict() -> Dictionary:
     }
 
 func from_dict(data: Dictionary) -> void:
+    id = data.get("id", id)
     pos_qr = data.get("pos_qr", pos_qr)
     var path: String = data.get("data_path", "")
     if path != "":

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -30,7 +30,7 @@ func _on_tile_clicked(qr: Vector2i) -> void:
             selected_unit.position = hex_map.axial_to_world(next)
             for i in range(GameState.units.size()):
                 var u: Dictionary = GameState.units[i]
-                if u.get("type", "") == selected_unit.type:
+                if u.get("id", "") == selected_unit.id:
                     GameState.units[i] = selected_unit.to_dict()
                     break
             hex_map.reveal_area(next, 1)
@@ -41,6 +41,7 @@ func spawn_unit_at_center() -> void:
     var data_res: UnitData = load("res://resources/units/footman.tres")
     if data_res:
         u.apply_data(data_res)
+    u.id = UUID.new_uuid_string()
     units_root.add_child(u)
     u.pos_qr = Vector2i.ZERO
     u.position = hex_map.axial_to_world(u.pos_qr)

--- a/tests/test_game_state.gd
+++ b/tests/test_game_state.gd
@@ -47,7 +47,9 @@ func test_unit_stats_persist(res) -> void:
     _remove_save(gs)
 
     gs.units.clear()
+    var uid := "test-unit-id"
     gs.units.append({
+        "id": uid,
         "type": "Footman",
         "data_path": "res://resources/units/footman.tres",
         "pos_qr": Vector2i(1, 2),
@@ -58,13 +60,13 @@ func test_unit_stats_persist(res) -> void:
     gs.units.clear()
     gs.load()
 
-    if gs.units.size() != 1:
+    if gs.units.size() != 1 or gs.units[0].get("id", "") != uid:
         res.fail("unit not loaded")
         return
     var u_dict = gs.units[0]
     var unit_scene: PackedScene = load("res://scenes/units/Unit.tscn")
     var unit = unit_scene.instantiate()
     unit.from_dict(u_dict)
-    if unit.hp != 55 or unit.atk != 20 or unit.def != 8 or abs(unit.move - 1.5) > 0.01:
+    if unit.id != uid or unit.hp != 55 or unit.atk != 20 or unit.def != 8 or abs(unit.move - 1.5) > 0.01:
         res.fail("unit stats not preserved")
 


### PR DESCRIPTION
## Summary
- assign each unit a UUID and serialize it
- track units in world and GameState by id
- update tests to use id persistence

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c161d8aac083308bcbf376e3a967bf