### PR TITLE
refactor: centralize hex helpers in HexUtils

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -91,21 +91,9 @@ func _unhandled_input(event: InputEvent) -> void:
             print("Hex %d,%d terrain %s" % [cell.x, cell.y, terrain])
             emit_signal("tile_clicked", cell)
 
-static func axial_neighbors(q: int, r: int) -> Array[Vector2i]:
-    var res: Array[Vector2i] = []
-    for d in HexUtils.HEX_DIRS:
-        res.append(Vector2i(q + d.x, r + d.y))
-    return res
-
-static func axial_distance(a: Vector2i, b: Vector2i) -> int:
-    var dq := a.x - b.x
-    var dr := a.y - b.y
-    var ds := -dq - dr
-    return max(abs(dq), abs(dr), abs(ds))
-
 func reveal_area(center: Vector2i, radius: int = 2) -> void:
     for coord in GameState.tiles.keys():
-        if axial_distance(coord, center) <= radius:
+        if HexUtils.axial_distance(coord, center) <= radius:
             GameState.tiles[coord]["explored"] = true
             if fog_map != null:
                 fog_map.set_cell(0, coord, -1, Vector2i.ZERO)

--- a/scripts/world/HexUtils.gd
+++ b/scripts/world/HexUtils.gd
@@ -21,3 +21,15 @@ static func world_to_axial(pos: Vector2, hex_radius: float) -> Vector2i:
     var q := (sqrt(3.0) / 3.0 * pos.x - pos.y / 3.0) / hex_radius
     var r := (2.0 / 3.0 * pos.y) / hex_radius
     return Vector2i(int(round(q)), int(round(r)))
+
+static func axial_neighbors(q: int, r: int) -> Array[Vector2i]:
+    var res: Array[Vector2i] = []
+    for d in HEX_DIRS:
+        res.append(Vector2i(q + d.x, r + d.y))
+    return res
+
+static func axial_distance(a: Vector2i, b: Vector2i) -> int:
+    var dq := a.x - b.x
+    var dr := a.y - b.y
+    var ds := -dq - dr
+    return max(abs(dq), abs(dr), abs(ds))

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -1,6 +1,7 @@
 extends Node
 
 const HexMapBase = preload("res://scripts/world/HexMap.gd")
+const HexUtils = preload("res://scripts/world/HexUtils.gd")
 
 class DummyHexMap extends HexMapBase:
     func _init():
@@ -11,7 +12,7 @@ class DummyHexMap extends HexMapBase:
         pass
     func reveal_area(center: Vector2i, radius: int = 2) -> void:
         for coord in GameState.tiles.keys():
-            if HexMapBase.axial_distance(coord, center) <= radius:
+            if HexUtils.axial_distance(coord, center) <= radius:
                 GameState.tiles[coord]["explored"] = true
 
 func _reset_tiles() -> void:


### PR DESCRIPTION
## Summary
- move axial distance and neighbor helpers into HexUtils
- adjust HexMap and tests to use HexUtils

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found: godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68c161e0fc148330818aaa3074579ab5