### PR TITLE
refactor: centralize resource constants

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -4,15 +4,18 @@ const WOOD_PER_TICK := 0.2
 const FOOD_PER_TICK := 0.1
 const STEAM_PER_TICK := 0.2
 
+const Resources = preload("res://scripts/core/Resources.gd")
+
 var res := {
-    "wood": 0.0,
-    "food": 0.0,
-    "ore": 0.0,
-    "research": 0.0,
-    "influence": 0.0,
-    "steam": 0.0,
-    "sisu": 0.0,
-    "morale": 100.0,
+    Resources.WOOD: 0.0,
+    Resources.FOOD: 0.0,
+    Resources.ORE: 0.0,
+    Resources.RESEARCH: 0.0,
+    Resources.INFLUENCE: 0.0,
+    Resources.STEAM: 0.0,
+    Resources.SISU: 0.0,
+    Resources.MORALE: 100.0,
+    Resources.GOLD: 0.0,
 }
 
 var last_timestamp: int = 0
@@ -27,9 +30,9 @@ func _ready() -> void:
     GameClock.tick.connect(_on_tick)
 
 func _on_tick() -> void:
-    res["wood"] += WOOD_PER_TICK
-    res["food"] += FOOD_PER_TICK
-    res["steam"] += STEAM_PER_TICK
+    res[Resources.WOOD] += WOOD_PER_TICK
+    res[Resources.FOOD] += FOOD_PER_TICK
+    res[Resources.STEAM] += STEAM_PER_TICK
 
 func save() -> void:
     last_timestamp = Time.get_unix_time_from_system()
@@ -93,9 +96,9 @@ func load_state() -> void:
     if elapsed > 0:
         var ticks := int(elapsed / GameClock.TICK_INTERVAL)
         if ticks > 0:
-            res["wood"] += WOOD_PER_TICK * ticks
-            res["food"] += FOOD_PER_TICK * ticks
-            res["steam"] += STEAM_PER_TICK * ticks
+            res[Resources.WOOD] += WOOD_PER_TICK * ticks
+            res[Resources.FOOD] += FOOD_PER_TICK * ticks
+            res[Resources.STEAM] += STEAM_PER_TICK * ticks
     last_timestamp = now
     save()
 

--- a/scripts/core/Resources.gd
+++ b/scripts/core/Resources.gd
@@ -1,0 +1,11 @@
+class_name Resources
+
+const WOOD := "wood"
+const FOOD := "food"
+const ORE := "ore"
+const RESEARCH := "research"
+const INFLUENCE := "influence"
+const STEAM := "steam"
+const SISU := "sisu"
+const MORALE := "morale"
+const GOLD := "gold"

--- a/scripts/world/MapGenerator.gd
+++ b/scripts/world/MapGenerator.gd
@@ -6,6 +6,7 @@ extends Node2D
 @export var hex_radius: float = 32.0
 
 const HexUtils = preload("res://scripts/world/HexUtils.gd")
+const Resources = preload("res://scripts/core/Resources.gd")
 var noise := FastNoiseLite.new()
 @onready var hex_tile_scene: PackedScene = preload("res://scenes/world/HexTile.tscn")
 
@@ -29,9 +30,9 @@ func generate_map() -> void:
             var resource_type := ""
             var roll := RNG.randf()
             if roll < 0.1:
-                resource_type = "gold"
+                resource_type = Resources.GOLD
             elif roll < 0.25:
-                resource_type = "wood"
+                resource_type = Resources.WOOD
             hex.q = q
             hex.r = r
             hex.terrain = terrain_type

--- a/tests/test_action.gd
+++ b/tests/test_action.gd
@@ -3,13 +3,14 @@ extends Node
 var Action = preload("res://scripts/core/Action.gd")
 var Policy = preload("res://scripts/policies/Policy.gd")
 var GameEvent = preload("res://scripts/events/Event.gd")
+var Resources = preload("res://scripts/core/Resources.gd")
 
 func test_policy_apply_and_cooldown(res):
     var gs = Engine.get_main_loop().root.get_node("GameState")
     var orig = gs.res.duplicate()
-    gs.res["gold"] = 100.0
-    gs.res["morale"] = 0.0
-    gs.res["food"] = 0.0
+    gs.res[Resources.GOLD] = 100.0
+    gs.res[Resources.MORALE] = 0.0
+    gs.res[Resources.FOOD] = 0.0
     var policy: Policy = load("res://resources/policies/tax_relief.tres")
     if not (policy is Action):
         res.fail("Policy does not inherit Action")
@@ -18,7 +19,7 @@ func test_policy_apply_and_cooldown(res):
         res.fail("Policy failed to apply")
         gs.res = orig
         return
-    if int(gs.res["gold"]) != 80 or int(gs.res["morale"]) != 10:
+    if int(gs.res[Resources.GOLD]) != 80 or int(gs.res[Resources.MORALE]) != 10:
         res.fail("Policy effects not applied")
     if policy.apply():
         res.fail("Cooldown not enforced")
@@ -27,9 +28,9 @@ func test_policy_apply_and_cooldown(res):
 func test_event_inherits_action(res):
     var gs = Engine.get_main_loop().root.get_node("GameState")
     var orig = gs.res.duplicate()
-    gs.res["gold"] = 100.0
-    gs.res["morale"] = 0.0
-    gs.res["food"] = 0.0
+    gs.res[Resources.GOLD] = 100.0
+    gs.res[Resources.MORALE] = 0.0
+    gs.res[Resources.FOOD] = 0.0
     var ev: GameEvent = load("res://resources/events/rain.tres")
     if not (ev is Action):
         res.fail("Event does not inherit Action")
@@ -42,7 +43,7 @@ func test_event_inherits_action(res):
         res.fail("Event failed to apply")
         gs.res = orig
         return
-    if int(gs.res["food"]) != 20:
+    if int(gs.res[Resources.FOOD]) != 20:
         res.fail("Event effect not applied")
     gs.res = orig
 

--- a/tests/test_building.gd
+++ b/tests/test_building.gd
@@ -1,5 +1,6 @@
 extends Node
 var Building = preload("res://scripts/core/Building.gd")
+var Resources = preload("res://scripts/core/Resources.gd")
 
 func test_upgrade_increments_level(res):
     var building = Building.new()
@@ -10,9 +11,9 @@ func test_upgrade_increments_level(res):
 
 func test_getters_return_values(res):
     var building = Building.new()
-    building.construction_cost = {"gold": 100}
-    building.production_rates = {"wood": 10}
-    if building.get_construction_cost().get("gold", 0) != 100:
+    building.construction_cost = {Resources.GOLD: 100}
+    building.production_rates = {Resources.WOOD: 10}
+    if building.get_construction_cost().get(Resources.GOLD, 0) != 100:
         res.fail("Construction cost incorrect")
-    if building.get_production_rates().get("wood", 0) != 10:
+    if building.get_production_rates().get(Resources.WOOD, 0) != 10:
         res.fail("Production rate incorrect")

--- a/tests/test_game_state.gd
+++ b/tests/test_game_state.gd
@@ -1,5 +1,6 @@
 extends Node
 
+var Resources = preload("res://scripts/core/Resources.gd")
 func _remove_save(gs) -> void:
     if FileAccess.file_exists(gs.SAVE_PATH):
         DirAccess.remove_absolute(gs.SAVE_PATH)
@@ -29,14 +30,14 @@ func test_offline_gain(res) -> void:
     file.store_string(JSON.stringify(data))
     file.close()
 
-    gs.res["wood"] = 0.0
-    gs.res["food"] = 0.0
-    gs.res["steam"] = 0.0
+    gs.res[Resources.WOOD] = 0.0
+    gs.res[Resources.FOOD] = 0.0
+    gs.res[Resources.STEAM] = 0.0
     gs.load()
 
     var expected_ticks := int(5 / clock.TICK_INTERVAL)
     var expected: float = gs.WOOD_PER_TICK * expected_ticks
-    if gs.res["wood"] < expected - 0.001:
+    if gs.res[Resources.WOOD] < expected - 0.001:
         res.fail("offline gains not applied")
 
 func test_unit_stats_persist(res) -> void:

--- a/tests/test_resources.gd
+++ b/tests/test_resources.gd
@@ -1,0 +1,21 @@
+extends Node
+var Resources = preload("res://scripts/core/Resources.gd")
+
+func test_game_state_resources(res) -> void:
+    var gs = Engine.get_main_loop().root.get_node("GameState")
+    var keys := gs.res.keys()
+    keys.sort()
+    var expected := [
+        Resources.WOOD,
+        Resources.FOOD,
+        Resources.ORE,
+        Resources.RESEARCH,
+        Resources.INFLUENCE,
+        Resources.STEAM,
+        Resources.SISU,
+        Resources.MORALE,
+        Resources.GOLD,
+    ]
+    expected.sort()
+    if keys != expected:
+        res.fail("resource keys mismatch: %s" % [keys])

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -15,6 +15,7 @@ var test_script_paths := [
     "res://tests/test_hexmap.gd",
     "res://tests/test_pathing.gd",
     "res://tests/test_action.gd",
+    "res://tests/test_resources.gd",
 ]
 
 func _init() -> void:


### PR DESCRIPTION
## Summary
- add Resources constants for all resource names
- use resource constants across GameState, MapGenerator, and tests
- cover GameState resource keys with a new sanity test

## Testing
- `./godot4/Godot_v4.2.2-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Could not resolve class "HexMap")*

------
https://chatgpt.com/codex/tasks/task_e_68c161fb500c83308ae0186e3483be1c