### PR TITLE
Add hostile tile tags with visible markers

### DIFF
--- a/scripts/world/HostileMarker.gd
+++ b/scripts/world/HostileMarker.gd
@@ -1,0 +1,7 @@
+extends Node2D
+
+var size: float = 8.0
+
+func _draw() -> void:
+    var points: PackedVector2Array = [Vector2(0, -size), Vector2(size, size), Vector2(-size, size)]
+    draw_polygon(points, [Color(1,0,0)])


### PR DESCRIPTION
## Summary
- Tag non-lake tiles as hostile or wildlife during map generation
- Show red triangle markers on hostile tiles using procedural draw

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: project uses newer engine version)*

------
https://chatgpt.com/codex/tasks/task_e_68c17781931883309b71542815e75aab