### PR TITLE
Add auto-resolve combat and tests

### DIFF
--- a/scripts/battle/AutoResolve.gd
+++ b/scripts/battle/AutoResolve.gd
@@ -1,0 +1,58 @@
+extends Node
+class_name AutoResolve
+
+static func resolve(friendly: Array, enemies: Array, terrain: String) -> Dictionary:
+    var rounds: int = 5 + int(RNG.randf() * 16.0)
+    var atk_mod := 1.0
+    var def_mod := 1.0
+    if terrain == "hill":
+        atk_mod += 0.1
+    elif terrain == "forest":
+        def_mod += 0.2
+    for _i in range(rounds):
+        if friendly.is_empty() or enemies.is_empty():
+            break
+        # attackers strike defenders
+        for j in range(friendly.size()):
+            if enemies.is_empty():
+                break
+            var idx := int(RNG.randf() * enemies.size())
+            var a: Dictionary = friendly[j]
+            var d: Dictionary = enemies[idx]
+            var dmg := max(1, int(round(a.get("atk", 0) * atk_mod - d.get("def", 0) * def_mod)))
+            d["hp"] = d.get("hp", 0) - dmg
+            if d["hp"] <= 0:
+                enemies.remove_at(idx)
+            else:
+                enemies[idx] = d
+        # defenders strike back
+        for j in range(enemies.size()):
+            if friendly.is_empty():
+                break
+            var idx := int(RNG.randf() * friendly.size())
+            var a2: Dictionary = enemies[j]
+            var d2: Dictionary = friendly[idx]
+            var dmg2 := max(1, int(round(a2.get("atk", 0) * atk_mod - d2.get("def", 0) * def_mod)))
+            d2["hp"] = d2.get("hp", 0) - dmg2
+            if d2["hp"] <= 0:
+                friendly.remove_at(idx)
+            else:
+                friendly[idx] = d2
+    var winner := "draw"
+    if enemies.is_empty() and not friendly.is_empty():
+        winner = "friendly"
+    elif friendly.is_empty() and not enemies.is_empty():
+        winner = "enemy"
+    elif not friendly.is_empty() and not enemies.is_empty():
+        var fhp := 0
+        for f in friendly:
+            fhp += f.get("hp", 0)
+        var ehp := 0
+        for e in enemies:
+            ehp += e.get("hp", 0)
+        winner = fhp >= ehp ? "friendly" : "enemy"
+    return {
+        "friendly": friendly,
+        "enemies": enemies,
+        "winner": winner,
+    }

--- a/tests/test_battle.gd
+++ b/tests/test_battle.gd
@@ -1,0 +1,69 @@
+extends Node
+
+var Resources = preload("res://scripts/core/Resources.gd")
+
+func _remove_save(gs) -> void:
+    if FileAccess.file_exists(gs.SAVE_PATH):
+        DirAccess.remove_absolute(gs.SAVE_PATH)
+
+func test_battle_player_win(res) -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    _remove_save(gs)
+    var orig = gs.res.duplicate()
+    gs.units.clear()
+    gs.tiles.clear()
+    var world_scene: PackedScene = load("res://scenes/world/World.tscn")
+    var world = world_scene.instantiate()
+    tree.root.add_child(world)
+    world.spawn_unit_at_center()
+    var target := Vector2i(1, 0)
+    var tdata = gs.tiles.get(target, {})
+    tdata["terrain"] = "hill"
+    tdata["owner"] = "enemy"
+    tdata["hostiles"] = [{"hp":50,"atk":5,"def":1}]
+    gs.tiles[target] = tdata
+    world._on_tile_clicked(target)
+    tdata = gs.tiles[target]
+    if tdata.get("owner", "") != "player":
+        res.fail("Tile not captured")
+    if abs(gs.res[Resources.INFLUENCE] - (orig.get(Resources.INFLUENCE, 0.0) + 0.5)) > 0.01:
+        res.fail("Influence not granted")
+    world.queue_free()
+    gs.res = orig
+    gs.units.clear()
+    gs.tiles.clear()
+    _remove_save(gs)
+
+func test_battle_player_loss(res) -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    _remove_save(gs)
+    var orig = gs.res.duplicate()
+    gs.units.clear()
+    gs.tiles.clear()
+    var world_scene: PackedScene = load("res://scenes/world/World.tscn")
+    var world = world_scene.instantiate()
+    tree.root.add_child(world)
+    world.spawn_unit_at_center()
+    var target := Vector2i(1, 0)
+    var tdata = gs.tiles.get(target, {})
+    tdata["terrain"] = "forest"
+    tdata["owner"] = "enemy"
+    tdata["hostiles"] = [{"hp":200,"atk":20,"def":5}]
+    gs.tiles[target] = tdata
+    world._on_tile_clicked(target)
+    tdata = gs.tiles[target]
+    if tdata.get("owner", "") == "player":
+        res.fail("Tile should remain enemy")
+    var expected_morale = orig.get(Resources.MORALE, 0.0) - 1.0
+    if abs(gs.res[Resources.MORALE] - expected_morale) > 0.01:
+        res.fail("Morale not reduced")
+    var expected_sisu = orig.get(Resources.SISU, 0.0) + 1.0
+    if abs(gs.res[Resources.SISU] - expected_sisu) > 0.01:
+        res.fail("Sisu not increased")
+    world.queue_free()
+    gs.res = orig
+    gs.units.clear()
+    gs.tiles.clear()
+    _remove_save(gs)

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -17,6 +17,7 @@ var test_script_paths := [
     "res://tests/test_action.gd",
     "res://tests/test_resources.gd",
     "res://tests/test_world.gd",
+    "res://tests/test_battle.gd",
 ]
 
 func _init() -> void:


### PR DESCRIPTION
## Summary
- Implement AutoResolve battle simulation with terrain bonuses and random rounds
- Trigger combat on entering hostile tiles, updating ownership and resources
- Add tests for player win and loss scenarios

## Testing
- `godot -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get update && apt-cache search godot` *(no Godot packages available)*
- `wget https://downloads.tuxfamily.org/godotengine/4.1.2/Godot_v4.1.2-stable_linux.x86_64.zip` *(network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c177b451a083309df1d88ba857305d