### PR TITLE
feat: add event system with overlay

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -1,0 +1,54 @@
+extends Node
+class_name EventManager
+
+var events: Array = []
+var current_event: GameEvent = null
+var _ticks_until_event: int = 0
+
+const GameEvent = preload("res://scripts/events/Event.gd")
+const OVERLAY_SCENE := preload("res://scenes/ui/EventOverlay.tscn")
+
+func _ready() -> void:
+    _load_events()
+    GameClock.tick.connect(_on_tick)
+    _schedule_next_event()
+
+func _load_events() -> void:
+    events.clear()
+    for file in DirAccess.get_files_at("res://resources/events"):
+        if file.get_extension() == "tres":
+            var ev: GameEvent = load("res://resources/events/%s" % file)
+            events.append(ev)
+
+func _schedule_next_event() -> void:
+    _ticks_until_event = 30 + int(RNG.randf() * 21)
+
+func _on_tick() -> void:
+    if current_event:
+        return
+    _ticks_until_event -= 1
+    if _ticks_until_event <= 0:
+        if events.size() > 0:
+            var idx := int(RNG.randf() * events.size())
+            start_event(events[idx])
+
+func start_event(ev: GameEvent) -> void:
+    if current_event:
+        return
+    current_event = ev
+    GameClock.stop()
+    var overlay = OVERLAY_SCENE.instantiate()
+    overlay.show_event(ev)
+    overlay.choice_selected.connect(_on_choice_selected)
+    get_tree().root.add_child(overlay)
+
+func _on_choice_selected(choice: Dictionary) -> void:
+    var costs: Dictionary = choice.get("costs", {})
+    for k in costs.keys():
+        GameState.res[k] = GameState.res.get(k, 0) - costs[k]
+    var effects: Dictionary = choice.get("effects", {})
+    for k in effects.keys():
+        GameState.res[k] = GameState.res.get(k, 0) + effects[k]
+    current_event = null
+    GameClock.start()
+    _schedule_next_event()

--- a/project.godot
+++ b/project.godot
@@ -10,6 +10,7 @@ config/features=PackedStringArray("4.0")
 GameState="*res://autoload/GameState.gd"
 GameClock="*res://autoload/GameClock.gd"
 RNG="*res://autoload/RNG.gd"
+EventManager="*res://autoload/EventManager.gd"
 
 [gui]
 theme/custom="res://resources/Theme.tres"

--- a/resources/events/rain.tres
+++ b/resources/events/rain.tres
@@ -3,6 +3,8 @@
 [resource]
 name = "Rain"
 description = "Bountiful rain increases food production."
-effects = {"food": 20}
-costs = {}
-cooldown = 0.0
+choices = [{
+"text": "Collect water",
+"effects": {"food": 20},
+"costs": {}
+}]

--- a/scenes/ui/EventOverlay.tscn
+++ b/scenes/ui/EventOverlay.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=2]
+
+[ext_resource path="res://scripts/ui/EventOverlay.gd" type="Script" id="1"]
+
+[node name="EventOverlay" type="CanvasLayer" script=ExtResource("1")]
+
+[node name="Panel" type="Panel" parent="."]
+anchor_left = 0.25
+anchor_right = 0.75
+anchor_top = 0.25
+anchor_bottom = 0.75
+
+[node name="Title" type="Label" parent="Panel"]
+anchor_left = 0.0
+anchor_right = 1.0
+anchor_top = 0.0
+anchor_bottom = 0.2
+text = "Title"
+
+[node name="Description" type="Label" parent="Panel"]
+anchor_left = 0.0
+anchor_right = 1.0
+anchor_top = 0.2
+anchor_bottom = 0.5
+text = "Description"
+
+[node name="Choices" type="VBoxContainer" parent="Panel"]
+anchor_left = 0.0
+anchor_right = 1.0
+anchor_top = 0.5
+anchor_bottom = 1.0

--- a/scripts/events/Event.gd
+++ b/scripts/events/Event.gd
@@ -1,8 +1,9 @@
-extends Action
+extends Resource
 class_name GameEvent
 
 @export var name: String = ""
 @export var description: String = ""
+@export var choices: Array[Dictionary] = []
 
 func can_trigger() -> bool:
-    return can_apply()
+    return true

--- a/scripts/ui/EventOverlay.gd
+++ b/scripts/ui/EventOverlay.gd
@@ -1,0 +1,19 @@
+extends CanvasLayer
+class_name EventOverlay
+
+signal choice_selected(choice: Dictionary)
+
+const GameEvent = preload("res://scripts/events/Event.gd")
+
+@onready var title_label: Label = $Panel/Title
+@onready var description_label: Label = $Panel/Description
+@onready var choices_container: VBoxContainer = $Panel/Choices
+
+func show_event(ev: GameEvent) -> void:
+    title_label.text = ev.name
+    description_label.text = ev.description
+    for c in ev.choices:
+        var btn := Button.new()
+        btn.text = c.get("text", "Choice")
+        btn.pressed.connect(func(): choice_selected.emit(c); queue_free())
+        choices_container.add_child(btn)

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -73,11 +73,8 @@ func _on_event_pressed() -> void:
     var idx := event_selector.get_selected()
     if idx >= 0 and idx < _events.size():
         var ev: GameEvent = _events[idx]
-        if ev.apply():
-            update_resources(GameState.res)
-            event_label.text = "%s occurred!" % ev.name
-        else:
-            event_label.text = "%s on cooldown" % ev.name
+        EventManager.start_event(ev)
+        event_label.text = "%s triggered" % ev.name
 
 func _on_building_selected(index: int) -> void:
     building_selected.emit(building_selector.get_item_text(index))


### PR DESCRIPTION
## Summary
- add EventManager autoload to trigger random events and pause gameplay
- introduce reusable EventOverlay UI for event choices
- update event data and HUD integration for new system

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c17854d40c8330bc8efbeac4917790