### PR TITLE
Add raider spawns and pathing logic

### DIFF
--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -10,9 +10,14 @@ var unit_scene: PackedScene = preload("res://scenes/units/Unit.tscn")
 const Pathing = preload("res://scripts/world/Pathing.gd")
 const AutoResolve = preload("res://scripts/battle/AutoResolve.gd")
 const Resources = preload("res://scripts/core/Resources.gd")
+const HexUtils = preload("res://scripts/world/HexUtils.gd")
+
+var raiders: Array = []
+var _tick_counter: int = 0
 
 func _ready() -> void:
     hex_map.tile_clicked.connect(_on_tile_clicked)
+    GameClock.tick.connect(_on_game_tick)
     for data in GameState.units:
         var u = unit_scene.instantiate()
         u.from_dict(data)
@@ -38,6 +43,59 @@ func _on_tile_clicked(qr: Vector2i) -> void:
             hex_map.reveal_area(next, 1)
             _resolve_combat(next)
             GameState.save()
+
+func _on_game_tick() -> void:
+    _tick_counter += 1
+    if _tick_counter % 20 == 0:
+        _spawn_raiders()
+    _move_raiders()
+
+func _spawn_raiders() -> void:
+    for coord in GameState.tiles.keys():
+        var tile: Dictionary = GameState.tiles[coord]
+        if tile.get("hostile", false):
+            var target: Vector2i = _find_target(coord)
+            var path: Array[Vector2i] = Pathing.bfs_path(coord, target, func(p: Vector2i):
+                return GameState.tiles.has(p) and GameState.tiles[p].get("terrain") != "lake"
+            )
+            if path.size() >= 2:
+                var r: Node = unit_scene.instantiate()
+                r.pos_qr = coord
+                r.position = hex_map.axial_to_world(coord)
+                var vis = r.get_node_or_null("Visual")
+                if vis:
+                    vis.color = Color(0,0,0)
+                units_root.add_child(r)
+                raiders.append({"node": r, "path": path, "step": 0})
+
+func _move_raiders() -> void:
+    for i in range(raiders.size() - 1, -1, -1):
+        var data: Dictionary = raiders[i]
+        var node = data["node"]
+        var path: Array[Vector2i] = data["path"]
+        var step: int = data["step"]
+        if step + 1 < path.size():
+            step += 1
+            var next: Vector2i = path[step]
+            node.pos_qr = next
+            node.position = hex_map.axial_to_world(next)
+            data["step"] = step
+            raiders[i] = data
+        else:
+            node.queue_free()
+            raiders.remove_at(i)
+
+func _find_target(start: Vector2i) -> Vector2i:
+    var best := Vector2i.ZERO
+    var best_dist := HexUtils.axial_distance(start, Vector2i.ZERO)
+    for coord in GameState.tiles.keys():
+        var tile: Dictionary = GameState.tiles[coord]
+        if tile.get("owner", "") == "player" and tile.get("building") != null:
+            var dist := HexUtils.axial_distance(start, coord)
+            if dist < best_dist:
+                best_dist = dist
+                best = coord
+    return best
 
 func spawn_unit_at_center() -> void:
     var u: Node = unit_scene.instantiate()
@@ -92,6 +150,7 @@ func _resolve_combat(pos: Vector2i) -> void:
     if selected_unit and not ids.has(selected_unit.id):
         selected_unit = null
     tile["hostiles"] = enemy_left
+    tile["hostile"] = not enemy_left.is_empty()
     if enemy_left.is_empty() and survivors.size() > 0:
         tile["owner"] = "player"
         GameState.res[Resources.INFLUENCE] = GameState.res.get(Resources.INFLUENCE, 0.0) + 0.5

--- a/tests/test_raiders.gd
+++ b/tests/test_raiders.gd
@@ -1,0 +1,44 @@
+extends Node
+
+func _setup_world():
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    gs.units.clear()
+    gs.tiles.clear()
+    gs.tiles[Vector2i(0,0)] = {"terrain": "forest", "owner": "player", "building": null, "explored": true}
+    gs.tiles[Vector2i(1,0)] = {"terrain": "lake", "owner": "none", "building": null, "explored": true}
+    gs.tiles[Vector2i(1,-1)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
+    gs.tiles[Vector2i(2,0)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true, "hostile": true}
+    gs.tiles[Vector2i(2,-1)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
+    var world_scene: PackedScene = load("res://scenes/world/World.tscn")
+    var world = world_scene.instantiate()
+    tree.root.add_child(world)
+    return world
+
+func test_raider_spawn_and_path(res) -> void:
+    var world = _setup_world()
+    for i in range(19):
+        world._on_game_tick()
+    if world.raiders.size() != 0:
+        res.fail("raider spawned early")
+        world.queue_free()
+        return
+    world._on_game_tick()
+    if world.raiders.size() != 1:
+        res.fail("raider did not spawn")
+        world.queue_free()
+        return
+    var raider = world.raiders[0]["node"]
+    if raider.pos_qr != Vector2i(2,-1):
+        res.fail("raider wrong first step %s" % raider.pos_qr)
+        world.queue_free()
+        return
+    world._on_game_tick()
+    if raider.pos_qr != Vector2i(1,-1):
+        res.fail("raider did not avoid lake")
+        world.queue_free()
+        return
+    world._on_game_tick()
+    if raider.pos_qr != Vector2i(0,0):
+        res.fail("raider did not reach center")
+    world.queue_free()

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -20,6 +20,7 @@ var test_script_paths := [
     "res://tests/test_events.gd",
     "res://tests/test_world.gd",
     "res://tests/test_battle.gd",
+    "res://tests/test_raiders.gd",
 ]
 
 func _init() -> void:


### PR DESCRIPTION
## Summary
- Spawn raider units from hostile camps every 20 ticks
- Raiders path toward nearest player structure or origin, avoiding lakes and moving 1 hex per tick
- Clear hostile flag after combat and add regression tests for raider behavior

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/finsim_AA-club/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c1818438348330a906a3df027aaa74