### PR TITLE
Add raider edge rule and sisu heal action

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -54,6 +54,7 @@ func _check_raider_base() -> void:
         res[Resources.MORALE] = res.get(Resources.MORALE, 0.0) - 5.0
         tile["hostiles"] = []
         tiles[origin] = tile
+        save()
 
 func save() -> void:
     last_timestamp = Time.get_unix_time_from_system()

--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -39,10 +39,21 @@ func _on_tick() -> void:
     res[Resources.WOOD] += WOOD_PER_TICK * mult
     res[Resources.FOOD] += FOOD_PER_TICK * mult
     res[Resources.LOYLY] += LOYLY_PER_TICK * mult
+    res[Resources.SISU] = min(res.get(Resources.SISU, 0.0), 10.0)
+    _check_raider_base()
     if modifier_ticks_remaining > 0:
         modifier_ticks_remaining -= 1
         if modifier_ticks_remaining <= 0:
             production_modifier = 1.0
+
+func _check_raider_base() -> void:
+    var origin := Vector2i.ZERO
+    var tile: Dictionary = tiles.get(origin, {})
+    var hostiles: Array = tile.get("hostiles", [])
+    if hostiles.size() > 0:
+        res[Resources.MORALE] = res.get(Resources.MORALE, 0.0) - 5.0
+        tile["hostiles"] = []
+        tiles[origin] = tile
 
 func save() -> void:
     last_timestamp = Time.get_unix_time_from_system()
@@ -84,6 +95,7 @@ func load_state() -> void:
         last_timestamp = Time.get_unix_time_from_system()
         return
     res = data.get("res", res)
+    res[Resources.SISU] = min(res.get(Resources.SISU, 0.0), 10.0)
     last_timestamp = int(data.get("last_timestamp", Time.get_unix_time_from_system()))
     tiles.clear()
     var tile_data: Dictionary = data.get("tiles", {})

--- a/scenes/ui/Hud.tscn
+++ b/scenes/ui/Hud.tscn
@@ -36,3 +36,10 @@ text = "No events"
 text = "Build"
 
 [node name="BuildingSelector" type="OptionButton" parent="."]
+
+[node name="SisuButton" type="Button" parent="."]
+text = "Spend Sisu (Heal 20%)"
+
+[node name="SisuCooldown" type="Timer" parent="."]
+wait_time = 10.0
+one_shot = true

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -4,6 +4,7 @@ signal start_pressed
 signal pause_pressed
 signal build_pressed
 signal building_selected
+signal sisu_pressed
 
 @onready var resources_label: Label = $ResourcesLabel
 @onready var tile_info_label: Label = $TileInfoLabel
@@ -17,6 +18,8 @@ signal building_selected
 @onready var building_selector: OptionButton = $BuildingSelector
 @onready var policy_selector: OptionButton = $PolicySelector
 @onready var event_selector: OptionButton = $EventSelector
+@onready var sisu_button: Button = $SisuButton
+@onready var sisu_cooldown: Timer = $SisuCooldown
 
 var _policies: Array[Policy] = []
 var _events: Array[GameEvent] = []
@@ -31,6 +34,8 @@ func _ready() -> void:
     policy_button.pressed.connect(_on_policy_pressed)
     event_button.pressed.connect(_on_event_pressed)
     build_button.pressed.connect(func(): build_pressed.emit())
+    sisu_button.pressed.connect(func(): sisu_pressed.emit())
+    sisu_cooldown.timeout.connect(func(): sisu_button.disabled = false)
     _populate_buildings()
     _populate_policies()
     _populate_events()
@@ -42,6 +47,10 @@ func _ready() -> void:
         policy_selector.select(0)
     if event_selector.item_count > 0:
         event_selector.select(0)
+
+func start_sisu_cooldown() -> void:
+    sisu_button.disabled = true
+    sisu_cooldown.start()
 
 func update_resources(resources: Dictionary) -> void:
     var keys := resources.keys()

--- a/scripts/ui/Main.gd
+++ b/scripts/ui/Main.gd
@@ -3,12 +3,14 @@ extends Node
 @onready var world: Node = $World
 @onready var reveal_btn: Button = $DebugUI/RevealAllButton
 @onready var spawn_btn: Button = $DebugUI/SpawnButton
+@onready var hud: CanvasLayer = $Hud
 
 func _ready() -> void:
     if world.has_signal("tile_clicked"):
         world.tile_clicked.connect(_on_tile_clicked)
     reveal_btn.pressed.connect(_on_reveal_all)
     spawn_btn.pressed.connect(_on_spawn)
+    hud.sisu_pressed.connect(_on_sisu_pressed)
 
 func _on_tile_clicked(qr: Vector2i) -> void:
     var data: Dictionary = GameState.tiles.get(qr, {})
@@ -19,3 +21,8 @@ func _on_reveal_all() -> void:
 
 func _on_spawn() -> void:
     world.spawn_unit_at_center()
+
+func _on_sisu_pressed() -> void:
+    if world.spend_sisu_heal():
+        hud.start_sisu_cooldown()
+        hud.update_resources(GameState.res)

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -104,9 +104,9 @@ func _resolve_combat(pos: Vector2i) -> void:
     GameState.tiles[pos] = tile
 
 func spend_sisu_heal() -> bool:
-    if GameState.res.get(Resources.SISU, 0.0) <= 0:
+    if GameState.res.get(Resources.SISU, 0.0) < 1.0:
         return false
-    GameState.res[Resources.SISU] -= 1
+    GameState.res[Resources.SISU] = GameState.res.get(Resources.SISU, 0.0) - 1.0
     for i in range(GameState.units.size()):
         var u: Dictionary = GameState.units[i]
         var ud: UnitData = load(u.get("data_path", "")) as UnitData

--- a/tests/test_edge_rules.gd
+++ b/tests/test_edge_rules.gd
@@ -1,0 +1,79 @@
+extends Node
+
+const Resources = preload("res://scripts/core/Resources.gd")
+
+func _remove_save(gs) -> void:
+    if FileAccess.file_exists(gs.SAVE_PATH):
+        DirAccess.remove_absolute(gs.SAVE_PATH)
+
+func test_raider_reaches_origin(res) -> void:
+    var gs = Engine.get_main_loop().root.get_node("GameState")
+    _remove_save(gs)
+    var orig = gs.res.duplicate()
+    gs.tiles.clear()
+    gs.res[Resources.MORALE] = 100.0
+    var tdata = {"hostiles":[{"hp":10,"atk":1,"def":0}]}
+    gs.tiles[Vector2i.ZERO] = tdata
+    gs._on_tick()
+    if int(gs.res[Resources.MORALE]) != 95:
+        res.fail("Morale not reduced by raider")
+    var tile = gs.tiles.get(Vector2i.ZERO, {})
+    if tile.get("hostiles", []) != []:
+        res.fail("Raider not despawned")
+    gs.res = orig
+    gs.tiles.clear()
+    _remove_save(gs)
+
+func test_sisu_cap(res) -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    _remove_save(gs)
+    var orig = gs.res.duplicate()
+    gs.res[Resources.SISU] = 9.0
+    gs.units.clear()
+    gs.tiles.clear()
+    var world_scene: PackedScene = load("res://scenes/world/World.tscn")
+    var world = world_scene.instantiate()
+    tree.root.add_child(world)
+    world.spawn_unit_at_center()
+    world.spawn_unit_at_center()
+    var target := Vector2i(1, 0)
+    var tdata = {"terrain":"forest","owner":"enemy","hostiles":[{"hp":200,"atk":20,"def":5}]}
+    gs.tiles[target] = tdata
+    world._on_tile_clicked(target)
+    if gs.res[Resources.SISU] > 10.0:
+        res.fail("Sisu cap exceeded")
+    world.queue_free()
+    gs.res = orig
+    gs.units.clear()
+    gs.tiles.clear()
+    _remove_save(gs)
+
+func test_spend_sisu_heal(res) -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    _remove_save(gs)
+    var orig = gs.res.duplicate()
+    gs.res[Resources.SISU] = 1.0
+    gs.units.clear()
+    gs.tiles.clear()
+    var world_scene: PackedScene = load("res://scenes/world/World.tscn")
+    var world = world_scene.instantiate()
+    tree.root.add_child(world)
+    world.spawn_unit_at_center()
+    for u in gs.units:
+        u["hp"] = int(u["hp"] / 2)
+    for child in world.units_root.get_children():
+        child.hp = int(child.hp / 2)
+    if not world.spend_sisu_heal():
+        res.fail("Spend Sisu failed")
+    var new_hp = gs.units[0]["hp"]
+    if new_hp <= 60:
+        res.fail("Unit not healed")
+    if gs.res[Resources.SISU] != 0.0:
+        res.fail("Sisu not spent")
+    world.queue_free()
+    gs.res = orig
+    gs.units.clear()
+    gs.tiles.clear()
+    _remove_save(gs)

--- a/tests/test_edge_rules.gd
+++ b/tests/test_edge_rules.gd
@@ -1,3 +1,4 @@
+# Tests for edge-rule behavior and Sisu mechanics
 extends Node
 
 const Resources = preload("res://scripts/core/Resources.gd")

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -20,6 +20,7 @@ var test_script_paths := [
     "res://tests/test_events.gd",
     "res://tests/test_world.gd",
     "res://tests/test_battle.gd",
+    "res://tests/test_edge_rules.gd",
 ]
 
 func _init() -> void:


### PR DESCRIPTION
## Summary
- Cap Sisu at 10 and allow healing units by spending Sisu
- Penalize morale and despawn raiders that reach the origin
- Add UI and tests for new Sisu mechanics

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18261310c8330a2ffd5ff6b5c220e