### PR TITLE
Add battle manager for automatic unit targeting

### DIFF
--- a/scenes/battle/BattleManager.tscn
+++ b/scenes/battle/BattleManager.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2]
+
+[ext_resource path="res://scripts/battle/BattleManager.gd" type="Script" id="1"]
+
+[node name="BattleManager" type="Node"]
+script = ExtResource("1")

--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4]
+[gd_scene load_steps=5]
 
 [ext_resource path="res://scenes/world/HexMap.tscn" type="PackedScene" id="1"]
 [ext_resource path="res://scripts/world/World.gd" type="Script" id="2"]
 [ext_resource path="res://scripts/world/FogMap.gd" type="Script" id="3"]
+[ext_resource path="res://scenes/battle/BattleManager.tscn" type="PackedScene" id="4"]
 
 [node name="World" type="Node2D"]
 script = ExtResource("2")
@@ -15,3 +16,5 @@ cell_tile_size = Vector2i(96, 84)
 script = ExtResource("3")
 
 [node name="Units" type="Node2D" parent="."]
+
+[node name="BattleManager" parent="." instance=ExtResource("4")]

--- a/scripts/battle/BattleManager.gd
+++ b/scripts/battle/BattleManager.gd
@@ -1,0 +1,48 @@
+extends Node
+class_name BattleManager
+
+const HexNavigator = preload("res://scripts/battle/HexNavigator.gd")
+
+var world: Node = null
+var hex_map: TileMap = null
+var units_root: Node2D = null
+
+func _ready() -> void:
+    world = get_parent()
+    if world:
+        hex_map = world.get_node("HexMap")
+        units_root = world.get_node("Units")
+
+func process_tick() -> void:
+    if GameState.units.is_empty():
+        return
+    var changed := false
+    for i in range(GameState.units.size()):
+        var data: Dictionary = GameState.units[i]
+        var path: Array[Vector2i] = HexNavigator.nearest_hostile_path(data.get("pos_qr", Vector2i.ZERO), GameState.tiles)
+        if path.size() <= 1:
+            if path.size() == 1:
+                world._resolve_combat(path[0])
+                changed = true
+            continue
+        var next: Vector2i = path[1]
+        var node = _find_unit_node(data.get("id", ""))
+        if node:
+            node.pos_qr = next
+            node.position = hex_map.axial_to_world(next)
+        data["pos_qr"] = next
+        GameState.units[i] = data
+        hex_map.reveal_area(next, 1)
+        changed = true
+        if path.size() == 2:
+            world._resolve_combat(next)
+    if changed:
+        GameState.save()
+
+func _find_unit_node(uid: String) -> Node:
+    if units_root == null:
+        return null
+    for child in units_root.get_children():
+        if child.id == uid:
+            return child
+    return null

--- a/scripts/battle/HexNavigator.gd
+++ b/scripts/battle/HexNavigator.gd
@@ -1,0 +1,32 @@
+extends Object
+class_name HexNavigator
+
+const HexUtils = preload("res://scripts/world/HexUtils.gd")
+
+static func nearest_hostile_path(start: Vector2i, tiles: Dictionary) -> Array[Vector2i]:
+    if tiles.is_empty():
+        return []
+    var frontier: Array[Vector2i] = [start]
+    var came_from: Dictionary = {start: start}
+    while frontier.size() > 0:
+        var current: Vector2i = frontier.pop_front()
+        var tile: Dictionary = tiles.get(current, {})
+        if tile.get("hostile", false):
+            var path: Array[Vector2i] = [current]
+            while current != start:
+                current = came_from[current]
+                path.append(current)
+            path.reverse()
+            return path
+        for dir in HexUtils.HEX_DIRS:
+            var nxt: Vector2i = current + dir
+            if came_from.has(nxt):
+                continue
+            if !tiles.has(nxt):
+                continue
+            var t: Dictionary = tiles[nxt]
+            if t.get("terrain", "") == "lake":
+                continue
+            frontier.append(nxt)
+            came_from[nxt] = current
+    return []

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -4,6 +4,7 @@ signal tile_clicked(qr: Vector2i)
 
 @onready var hex_map: TileMap = $HexMap
 @onready var units_root: Node2D = $Units
+@onready var battle_manager: Node = $BattleManager
 
 var selected_unit: Node = null
 var unit_scene: PackedScene = preload("res://scenes/units/Unit.tscn")
@@ -49,6 +50,8 @@ func _on_game_tick() -> void:
     if _tick_counter % 20 == 0:
         _spawn_raiders()
     _move_raiders()
+    if battle_manager:
+        battle_manager.process_tick()
 
 func _spawn_raiders() -> void:
     for coord in GameState.tiles.keys():


### PR DESCRIPTION
## Summary
- Add HexNavigator to path units toward nearest hostile hex
- Introduce BattleManager to move units and resolve combat each tick
- Hook battle manager into world scene and tick flow

## Testing
- `godot --headless --script tests/test_runner.gd` *(fails: Parse Error: Class "EventManager" hides an autoload singleton)*

------
https://chatgpt.com/codex/tasks/task_e_68c1831e75cc83308945dc364157526e