### PR TITLE
refactor: add raider manager

### DIFF
--- a/scripts/world/RaiderManager.gd
+++ b/scripts/world/RaiderManager.gd
@@ -1,0 +1,69 @@
+extends Node
+
+const Pathing = preload("res://scripts/world/Pathing.gd")
+const HexUtils = preload("res://scripts/world/HexUtils.gd")
+
+var hex_map: TileMap
+var units_root: Node2D
+var unit_scene: PackedScene
+
+var raiders: Array = []
+var _tick_counter: int = 0
+
+func setup(hmap: TileMap, units: Node2D, scene: PackedScene) -> void:
+    hex_map = hmap
+    units_root = units
+    unit_scene = scene
+
+func process_tick() -> void:
+    _tick_counter += 1
+    if _tick_counter % 20 == 0:
+        _spawn_raiders()
+    _move_raiders()
+
+func _spawn_raiders() -> void:
+    for coord in GameState.tiles.keys():
+        var tile: Dictionary = GameState.tiles[coord]
+        if tile.get("hostile", false):
+            var target: Vector2i = _find_target(coord)
+            var path: Array[Vector2i] = Pathing.bfs_path(coord, target, func(p: Vector2i):
+                return GameState.tiles.has(p) and GameState.tiles[p].get("terrain") != "lake"
+            )
+            if path.size() >= 2:
+                var r: Node = unit_scene.instantiate()
+                r.pos_qr = coord
+                r.position = hex_map.axial_to_world(coord)
+                var vis = r.get_node_or_null("Visual")
+                if vis:
+                    vis.color = Color(0,0,0)
+                units_root.add_child(r)
+                raiders.append({"node": r, "path": path, "step": 0})
+
+func _move_raiders() -> void:
+    for i in range(raiders.size() - 1, -1, -1):
+        var data: Dictionary = raiders[i]
+        var node = data["node"]
+        var path: Array[Vector2i] = data["path"]
+        var step: int = data["step"]
+        if step + 1 < path.size():
+            step += 1
+            var next: Vector2i = path[step]
+            node.pos_qr = next
+            node.position = hex_map.axial_to_world(next)
+            data["step"] = step
+            raiders[i] = data
+        else:
+            node.queue_free()
+            raiders.remove_at(i)
+
+func _find_target(start: Vector2i) -> Vector2i:
+    var best := Vector2i.ZERO
+    var best_dist := HexUtils.axial_distance(start, Vector2i.ZERO)
+    for coord in GameState.tiles.keys():
+        var tile: Dictionary = GameState.tiles[coord]
+        if tile.get("owner", "") == "player" and tile.get("building") != null:
+            var dist := HexUtils.axial_distance(start, coord)
+            if dist < best_dist:
+                best_dist = dist
+                best = coord
+    return best

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -11,12 +11,15 @@ var unit_scene: PackedScene = preload("res://scenes/units/Unit.tscn")
 const Pathing = preload("res://scripts/world/Pathing.gd")
 const AutoResolve = preload("res://scripts/battle/AutoResolve.gd")
 const Resources = preload("res://scripts/core/Resources.gd")
-const HexUtils = preload("res://scripts/world/HexUtils.gd")
 
-var raiders: Array = []
-var _tick_counter: int = 0
+const RaiderManager = preload("res://scripts/world/RaiderManager.gd")
+
+var raider_manager: RaiderManager
 
 func _ready() -> void:
+    raider_manager = RaiderManager.new()
+    add_child(raider_manager)
+    raider_manager.setup(hex_map, units_root, unit_scene)
     hex_map.tile_clicked.connect(_on_tile_clicked)
     GameClock.tick.connect(_on_game_tick)
     for data in GameState.units:
@@ -46,59 +49,10 @@ func _on_tile_clicked(qr: Vector2i) -> void:
             GameState.save()
 
 func _on_game_tick() -> void:
-    _tick_counter += 1
-    if _tick_counter % 20 == 0:
-        _spawn_raiders()
-    _move_raiders()
+    raider_manager.process_tick()
     if battle_manager:
         battle_manager.process_tick()
 
-func _spawn_raiders() -> void:
-    for coord in GameState.tiles.keys():
-        var tile: Dictionary = GameState.tiles[coord]
-        if tile.get("hostile", false):
-            var target: Vector2i = _find_target(coord)
-            var path: Array[Vector2i] = Pathing.bfs_path(coord, target, func(p: Vector2i):
-                return GameState.tiles.has(p) and GameState.tiles[p].get("terrain") != "lake"
-            )
-            if path.size() >= 2:
-                var r: Node = unit_scene.instantiate()
-                r.pos_qr = coord
-                r.position = hex_map.axial_to_world(coord)
-                var vis = r.get_node_or_null("Visual")
-                if vis:
-                    vis.color = Color(0,0,0)
-                units_root.add_child(r)
-                raiders.append({"node": r, "path": path, "step": 0})
-
-func _move_raiders() -> void:
-    for i in range(raiders.size() - 1, -1, -1):
-        var data: Dictionary = raiders[i]
-        var node = data["node"]
-        var path: Array[Vector2i] = data["path"]
-        var step: int = data["step"]
-        if step + 1 < path.size():
-            step += 1
-            var next: Vector2i = path[step]
-            node.pos_qr = next
-            node.position = hex_map.axial_to_world(next)
-            data["step"] = step
-            raiders[i] = data
-        else:
-            node.queue_free()
-            raiders.remove_at(i)
-
-func _find_target(start: Vector2i) -> Vector2i:
-    var best := Vector2i.ZERO
-    var best_dist := HexUtils.axial_distance(start, Vector2i.ZERO)
-    for coord in GameState.tiles.keys():
-        var tile: Dictionary = GameState.tiles[coord]
-        if tile.get("owner", "") == "player" and tile.get("building") != null:
-            var dist := HexUtils.axial_distance(start, coord)
-            if dist < best_dist:
-                best_dist = dist
-                best = coord
-    return best
 
 func spawn_unit_at_center() -> void:
     var u: Node = unit_scene.instantiate()

--- a/tests/test_raiders.gd
+++ b/tests/test_raiders.gd
@@ -19,16 +19,16 @@ func test_raider_spawn_and_path(res) -> void:
     var world = _setup_world()
     for i in range(19):
         world._on_game_tick()
-    if world.raiders.size() != 0:
+    if world.raider_manager.raiders.size() != 0:
         res.fail("raider spawned early")
         world.queue_free()
         return
     world._on_game_tick()
-    if world.raiders.size() != 1:
+    if world.raider_manager.raiders.size() != 1:
         res.fail("raider did not spawn")
         world.queue_free()
         return
-    var raider = world.raiders[0]["node"]
+    var raider = world.raider_manager.raiders[0]["node"]
     if raider.pos_qr != Vector2i(2,-1):
         res.fail("raider wrong first step %s" % raider.pos_qr)
         world.queue_free()


### PR DESCRIPTION
## Summary
- encapsulate raider spawning and movement in a new `RaiderManager`
- delegate raider ticks from `World` to `RaiderManager`
- adjust raider tests to use the new manager

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c18763a78c83309f598db863a78e45