### PR TITLE
feat: add building sprites and layer rendering

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -1,5 +1,7 @@
 extends Node
-class_name EventManager
+
+# The autoload provides the EventManager singleton; avoid registering a global
+# class name that conflicts with the autoload itself.
 
 var events: Array = []
 var current_event: GameEvent = null
@@ -17,8 +19,9 @@ func _load_events() -> void:
     events.clear()
     for file in DirAccess.get_files_at("res://resources/events"):
         if file.get_extension() == "tres":
-            var ev: GameEvent = load("res://resources/events/%s" % file)
-            events.append(ev)
+            var res := load("res://resources/events/%s" % file)
+            if res is GameEvent:
+                events.append(res)
 
 func _schedule_next_event() -> void:
     _ticks_until_event = 30 + int(RNG.randf() * 21)

--- a/scenes/world/HexMap.tscn
+++ b/scenes/world/HexMap.tscn
@@ -4,7 +4,7 @@
 [ext_resource path="res://resources/TileSet.tres" type="TileSet" id="2"]
 
 [node name="HexMap" type="TileMap"]
-layers = 1
+layers = 3
 tile_set = ExtResource("2")
 cell_tile_size = Vector2i(96, 84)
 script = ExtResource("1")


### PR DESCRIPTION
## Summary
- procedurally build 48x48 icons for sauna, farm, lumber, mine, and school
- render buildings on TileMap layer 2 above units, with autoloads resolved lazily
- remove binary building sprite files

## Testing
- `/tmp/godot4/Godot_v4.2.1-stable_linux.x86_64 --headless --path /workspace/finsim_AA-club -s tests/test_runner.gd` *(fails: Could not resolve class "HexMap")*


------
https://chatgpt.com/codex/tasks/task_e_68c182cc47a4833088eab31a174ead16