### PR TITLE
Check event prerequisites before triggering

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -33,10 +33,14 @@ func _on_tick() -> void:
     if _ticks_until_event <= 0:
         if events.size() > 0:
             var idx := int(RNG.randf() * events.size())
-            start_event(events[idx])
+            var ev: GameEvent = events[idx]
+            if ev.can_trigger():
+                start_event(ev)
 
 func start_event(ev: GameEvent) -> void:
     if current_event:
+        return
+    if not ev.can_trigger():
         return
     current_event = ev
     if ev.has_method("apply"):

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -73,8 +73,11 @@ func _on_event_pressed() -> void:
     var idx := event_selector.get_selected()
     if idx >= 0 and idx < _events.size():
         var ev: GameEvent = _events[idx]
-        EventManager.start_event(ev)
-        event_label.text = "%s triggered" % ev.name
+        if ev.can_trigger():
+            EventManager.start_event(ev)
+            event_label.text = "%s triggered" % ev.name
+        else:
+            event_label.text = "%s cannot trigger" % ev.name
 
 func _on_building_selected(index: int) -> void:
     building_selected.emit(building_selector.get_item_text(index))

--- a/tests/test_events.gd
+++ b/tests/test_events.gd
@@ -65,4 +65,25 @@ func test_cold_snap_event(res) -> void:
     gs.res[Resources.LOYLY] = 0.0
     gs.production_modifier = 1.0
     gs.modifier_ticks_remaining = 0
+
+func test_event_fails_prerequisites(res) -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    var em = tree.root.get_node("EventManager")
+    var orig = gs.res.duplicate()
+    gs.res[Resources.WOOD] = 0.0
+    var ev: GameEvent = load("res://resources/events/merchant.tres")
+    if ev.can_trigger():
+        res.fail("event unexpectedly triggerable")
+        gs.res = orig
+        return
+    em.start_event(ev)
+    var overlay_present := false
+    for child in tree.root.get_children():
+        if child.name == "EventOverlay":
+            overlay_present = true
+    _cleanup_overlays(tree)
+    gs.res = orig
+    if em.current_event != null or overlay_present:
+        res.fail("event started despite failing prerequisites")
         


### PR DESCRIPTION
## Summary
- Guard event auto-triggers by checking `can_trigger()` before starting random events
- Stop events from starting when prerequisites fail via `EventManager.start_event` and HUD checks
- Add regression test ensuring events with unmet prerequisites do not trigger

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18ddac0a083309b2ed5dbc0270050