### PR TITLE
Use queue-based BFS and add performance test

### DIFF
--- a/scripts/battle/HexNavigator.gd
+++ b/scripts/battle/HexNavigator.gd
@@ -7,9 +7,11 @@ static func nearest_hostile_path(start: Vector2i, tiles: Dictionary) -> Array[Ve
     if tiles.is_empty():
         return []
     var frontier: Array[Vector2i] = [start]
+    var head := 0
     var came_from: Dictionary = {start: start}
-    while frontier.size() > 0:
-        var current: Vector2i = frontier.pop_front()
+    while head < frontier.size():
+        var current: Vector2i = frontier[head]
+        head += 1
         var tile: Dictionary = tiles.get(current, {})
         if tile.get("hostile", false):
             var path: Array[Vector2i] = [current]

--- a/scripts/world/Pathing.gd
+++ b/scripts/world/Pathing.gd
@@ -1,15 +1,16 @@
 extends Object
 class_name Pathing
 const HexUtils = preload("res://scripts/world/HexUtils.gd")
-const HexMap = preload("res://scripts/world/HexMap.gd")
 
 static func bfs_path(start: Vector2i, goal: Vector2i, passable: Callable) -> Array[Vector2i]:
     if start == goal:
         return [start]
     var frontier: Array[Vector2i] = [start]
+    var head := 0
     var came_from: Dictionary = {start: start}
-    while frontier.size() > 0:
-        var current: Vector2i = frontier.pop_front()
+    while head < frontier.size():
+        var current: Vector2i = frontier[head]
+        head += 1
         if current == goal:
             break
         for dir in HexUtils.HEX_DIRS:

--- a/tests/test_bfs_performance.gd
+++ b/tests/test_bfs_performance.gd
@@ -1,0 +1,49 @@
+extends Node
+
+var Pathing = preload("res://scripts/world/Pathing.gd")
+var HexUtils = preload("res://scripts/world/HexUtils.gd")
+
+func _naive_bfs(start: Vector2i, goal: Vector2i, passable: Callable) -> Array[Vector2i]:
+    if start == goal:
+        return [start]
+    var frontier: Array[Vector2i] = [start]
+    var came_from: Dictionary = {start: start}
+    while frontier.size() > 0:
+        var current: Vector2i = frontier.pop_front()
+        if current == goal:
+            break
+        for dir in HexUtils.HEX_DIRS:
+            var nxt: Vector2i = current + dir
+            if !passable.call(nxt):
+                continue
+            if !came_from.has(nxt):
+                frontier.append(nxt)
+                came_from[nxt] = current
+    if !came_from.has(goal):
+        return []
+    var path: Array[Vector2i] = [goal]
+    var node: Vector2i = goal
+    while node != start:
+        node = came_from[node]
+        path.append(node)
+    path.reverse()
+    return path
+
+func test_bfs_performance(res) -> void:
+    var start := Vector2i(0, 0)
+    var goal := Vector2i(40, 0)
+    var passable := func(cell: Vector2i) -> bool:
+        return true
+    var queue_time := 0
+    var array_time := 0
+    var iterations := 3
+    for i in range(iterations):
+        var t0 := Time.get_ticks_usec()
+        Pathing.bfs_path(start, goal, passable)
+        queue_time += Time.get_ticks_usec() - t0
+    for i in range(iterations):
+        var t1 := Time.get_ticks_usec()
+        _naive_bfs(start, goal, passable)
+        array_time += Time.get_ticks_usec() - t1
+    if queue_time * 5 >= array_time * 6:
+        res.fail("Queue BFS %dus vs array BFS %dus" % [queue_time, array_time])

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -14,6 +14,7 @@ var test_script_paths := [
     "res://tests/test_game_state.gd",
     "res://tests/test_hexmap.gd",
     "res://tests/test_pathing.gd",
+    "res://tests/test_bfs_performance.gd",
     "res://tests/test_action.gd",
     "res://tests/test_resources.gd",
     "res://tests/test_prestige.gd",


### PR DESCRIPTION
## Summary
- Replace `frontier` arrays with index-based queues in `Pathing.bfs_path` and `HexNavigator.nearest_hostile_path` for O(1) dequeues.
- Add performance benchmark for BFS and wire it into test runner.

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: Could not resolve class "HexMap")*


------
https://chatgpt.com/codex/tasks/task_e_68c18deb81f4833081340ff82a35f2cf