### PR TITLE
Lock game speed to prestige levels

### DIFF
--- a/autoload/GameClock.gd
+++ b/autoload/GameClock.gd
@@ -6,12 +6,13 @@ const TICK_INTERVAL := 0.5
 var time: float = 0.0
 var running: bool = true
 var _accumulator: float = 0.0
+var speed_multiplier: float = 1.0
 
 func _process(delta: float) -> void:
     if not running:
         return
     time += delta
-    _accumulator += delta
+    _accumulator += delta * speed_multiplier
     while _accumulator >= TICK_INTERVAL:
         _accumulator -= TICK_INTERVAL
         emit_signal("tick")
@@ -21,3 +22,6 @@ func start() -> void:
 
 func stop() -> void:
     running = false
+
+func set_speed(mult: float) -> void:
+    speed_multiplier = max(mult, 0.0)

--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -3,6 +3,7 @@ extends Node
 const WOOD_PER_TICK := 0.2
 const FOOD_PER_TICK := 0.1
 const LOYLY_PER_TICK := 0.2
+const SPEED_PER_PRESTIGE := 0.25
 
 const Resources = preload("res://scripts/core/Resources.gd")
 const Prestige = preload("res://scripts/core/Prestige.gd")
@@ -116,6 +117,7 @@ func load_state() -> void:
             res[Resources.FOOD] += FOOD_PER_TICK * ticks * mult
             res[Resources.LOYLY] += LOYLY_PER_TICK * ticks * mult
     last_timestamp = now
+    _apply_speed_for_prestige()
     save()
 
 func load() -> void:
@@ -128,5 +130,10 @@ func prestige() -> void:
             res[k] = 0.0
     production_modifier = 1.0
     modifier_ticks_remaining = 0
+    _apply_speed_for_prestige()
     save()
+
+func _apply_speed_for_prestige() -> void:
+    var prestige_level: int = int(res.get(Resources.PRESTIGE, 0))
+    GameClock.set_speed(1.0 + prestige_level * SPEED_PER_PRESTIGE)
 


### PR DESCRIPTION
## Summary
- Tie GameClock speed to prestige level via a configurable multiplier
- Apply speed setting when loading and prestiging to lock game speed for NG+ tiers

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18fa08df883308b9ac4fbe66dd3c4