### PR TITLE
Add tutorial overlay and state tracking

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -28,6 +28,7 @@ var last_timestamp: int = 0
 
 var tiles: Dictionary = {}
 var units: Array = []
+var tutorial_done: bool = false
 
 const SAVE_PATH := "user://save.json"
 
@@ -64,6 +65,7 @@ func save() -> void:
         "last_timestamp": last_timestamp,
         "tiles": tile_data,
         "units": unit_data,
+        "tutorial_done": tutorial_done,
     }
     var file := FileAccess.open(SAVE_PATH, FileAccess.WRITE)
     if file:
@@ -85,6 +87,7 @@ func load_state() -> void:
         last_timestamp = Time.get_unix_time_from_system()
         return
     res = data.get("res", res)
+    tutorial_done = bool(data.get("tutorial_done", false))
     last_timestamp = int(data.get("last_timestamp", Time.get_unix_time_from_system()))
     tiles.clear()
     var tile_data: Dictionary = data.get("tiles", {})

--- a/scenes/ui/TutorialOverlay.tscn
+++ b/scenes/ui/TutorialOverlay.tscn
@@ -1,0 +1,26 @@
+[gd_scene load_steps=2]
+
+[ext_resource path="res://scripts/ui/TutorialOverlay.gd" type="Script" id="1"]
+
+[node name="TutorialOverlay" type="CanvasLayer" script=ExtResource("1")]
+
+[node name="Panel" type="Panel" parent="."]
+anchor_left = 0.25
+anchor_right = 0.75
+anchor_top = 0.25
+anchor_bottom = 0.75
+
+[node name="Text" type="RichTextLabel" parent="Panel"]
+anchor_left = 0.0
+anchor_right = 1.0
+anchor_top = 0.0
+anchor_bottom = 0.8
+text = "Welcome to the tutorial"
+autowrap_mode = 1
+
+[node name="NextButton" type="Button" parent="Panel"]
+anchor_left = 0.4
+anchor_right = 0.6
+anchor_top = 0.8
+anchor_bottom = 0.9
+text = "Next"

--- a/scripts/ui/Main.gd
+++ b/scripts/ui/Main.gd
@@ -1,6 +1,7 @@
 extends Node
 
 const Building = preload("res://scripts/core/Building.gd")
+const TutorialOverlay = preload("res://scenes/ui/TutorialOverlay.tscn")
 
 @onready var world: Node = $World
 @onready var hud: CanvasLayer = $Hud
@@ -10,6 +11,7 @@ const Building = preload("res://scripts/core/Building.gd")
 var _selected_building: Building = null
 var _last_clicked: Vector2i = Vector2i.ZERO
 var _buildings: Dictionary = {}
+var _tutorial_overlay: Node = null
 
 func _ready() -> void:
     for file in DirAccess.get_files_at("res://resources/buildings"):
@@ -26,6 +28,8 @@ func _ready() -> void:
     reveal_btn.pressed.connect(_on_reveal_all)
     spawn_btn.pressed.connect(_on_spawn)
     hud.update_resources(GameState.res)
+    if not GameState.tutorial_done:
+        start_tutorial()
 
 func _on_game_tick() -> void:
     hud.update_resources(GameState.res)
@@ -63,3 +67,15 @@ func _on_reveal_all() -> void:
 
 func _on_spawn() -> void:
     world.spawn_unit_at_center()
+
+func start_tutorial() -> void:
+    if _tutorial_overlay:
+        _tutorial_overlay.queue_free()
+    _tutorial_overlay = TutorialOverlay.instantiate()
+    add_child(_tutorial_overlay)
+    _tutorial_overlay.tutorial_completed.connect(_on_tutorial_completed)
+
+func _on_tutorial_completed() -> void:
+    GameState.tutorial_done = true
+    GameState.save()
+    _tutorial_overlay = null

--- a/scripts/ui/TutorialOverlay.gd
+++ b/scripts/ui/TutorialOverlay.gd
@@ -1,0 +1,29 @@
+extends CanvasLayer
+class_name TutorialOverlay
+
+signal tutorial_completed
+
+@onready var text_label: RichTextLabel = $Panel/Text
+@onready var next_button: Button = $Panel/NextButton
+
+var _steps: Array[String] = [
+    "Press the Start button to begin the clock.",
+    "Click a tile to select it.",
+    "Use the Build button to construct a structure."
+]
+var _index: int = 0
+
+func _ready() -> void:
+    next_button.pressed.connect(_on_next_pressed)
+    _show_step()
+
+func _show_step() -> void:
+    if _index < _steps.size():
+        text_label.text = _steps[_index]
+    else:
+        tutorial_completed.emit()
+        queue_free()
+
+func _on_next_pressed() -> void:
+    _index += 1
+    _show_step()


### PR DESCRIPTION
## Summary
- Add TutorialOverlay scene with RichTextLabel and Next button
- Guide users through starting clock, selecting tiles, and building structures
- Track tutorial completion in GameState and show overlay on first run

## Testing
- `apt-get update`
- `apt-get install -y godot3`
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project, config_version 5)*

------
https://chatgpt.com/codex/tasks/task_e_68c1912e5b3c8330b6014bb157a4bdb0