### PR TITLE
Guard event choices against insufficient resources

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -54,6 +54,9 @@ func start_event(ev: GameEvent) -> void:
 func _on_choice_selected(choice: Dictionary) -> void:
     var costs: Dictionary = choice.get("costs", {})
     for k in costs.keys():
+        if GameState.res.get(k, 0) < costs[k]:
+            return
+    for k in costs.keys():
         GameState.res[k] = GameState.res.get(k, 0) - costs[k]
     var effects: Dictionary = choice.get("effects", {})
     for k in effects.keys():

--- a/scripts/ui/EventOverlay.gd
+++ b/scripts/ui/EventOverlay.gd
@@ -15,5 +15,12 @@ func show_event(ev: GameEvent) -> void:
     for c in ev.choices:
         var btn := Button.new()
         btn.text = c.get("text", "Choice")
+        var affordable := true
+        var costs: Dictionary = c.get("costs", {})
+        for k in costs.keys():
+            if GameState.res.get(k, 0) < costs[k]:
+                affordable = false
+                break
+        btn.disabled = not affordable
         btn.pressed.connect(func(): choice_selected.emit(c); queue_free())
         choices_container.add_child(btn)

--- a/tests/test_events.gd
+++ b/tests/test_events.gd
@@ -86,4 +86,24 @@ func test_event_fails_prerequisites(res) -> void:
     gs.res = orig
     if em.current_event != null or overlay_present:
         res.fail("event started despite failing prerequisites")
+
+func test_unaffordable_choice_keeps_resources(res) -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    var em = tree.root.get_node("EventManager")
+    var clock = tree.root.get_node("GameClock")
+    clock.set_process(false)
+    var orig = gs.res.duplicate()
+    gs.res[Resources.WOOD] = 0.0
+    var ev: GameEvent = load("res://resources/events/merchant.tres")
+    em.start_event(ev)
+    var before := gs.res.duplicate()
+    em._on_choice_selected(ev.choices[0])
+    _cleanup_overlays(tree)
+    if gs.res != before:
+        res.fail("resources changed despite unaffordable choice")
+    gs.res = orig
+    em.current_event = null
+    clock.start()
+    clock.set_process(true)
         


### PR DESCRIPTION
## Summary
- Verify choice costs against GameState resources before applying
- Disable unaffordable event choices in the overlay
- Add test ensuring unaffordable choices don't change resources

## Testing
- `godot3-server -s tests/test_runner.gd` *(fails: project requires newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68c1916f9c2c833096398f0669ecaac0