### PR TITLE
Optimize raider spawning with hostile tile tracking

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -29,6 +29,7 @@ var last_timestamp: int = 0
 var tiles: Dictionary = {}
 var units: Array = []
 var tutorial_done: bool = false
+var hostile_tiles: Array[Vector2i] = []
 
 const SAVE_PATH := "user://save.json"
 
@@ -90,12 +91,15 @@ func load_state() -> void:
     tutorial_done = bool(data.get("tutorial_done", false))
     last_timestamp = int(data.get("last_timestamp", Time.get_unix_time_from_system()))
     tiles.clear()
+    hostile_tiles.clear()
     var tile_data: Dictionary = data.get("tiles", {})
     for key in tile_data.keys():
         var parts: PackedStringArray = key.split(",")
         if parts.size() == 2:
             var c := Vector2i(int(parts[0]), int(parts[1]))
             tiles[c] = tile_data[key]
+            if tile_data[key].get("hostile", false):
+                hostile_tiles.append(c)
     units.clear()
     for u in data.get("units", []):
         var pos_arr: Array = u.get("pos_qr", [0, 0])
@@ -109,6 +113,9 @@ func load_state() -> void:
             "pos_qr": Vector2i(int(pos_arr[0]), int(pos_arr[1])),
             "hp": int(u.get("hp", 0)),
         })
+
+    if hostile_tiles.is_empty():
+        update_hostile_tiles()
 
     var now := Time.get_unix_time_from_system()
     var elapsed := now - last_timestamp
@@ -139,4 +146,22 @@ func prestige() -> void:
 func _apply_speed_for_prestige() -> void:
     var prestige_level: int = int(res.get(Resources.PRESTIGE, 0))
     GameClock.set_speed(1.0 + prestige_level * SPEED_PER_PRESTIGE)
+
+func set_hostile(coord: Vector2i, hostile: bool) -> void:
+    var tile: Dictionary = tiles.get(coord, {})
+    if tile.is_empty():
+        return
+    tile["hostile"] = hostile
+    tiles[coord] = tile
+    if hostile:
+        if not hostile_tiles.has(coord):
+            hostile_tiles.append(coord)
+    else:
+        hostile_tiles.erase(coord)
+
+func update_hostile_tiles() -> void:
+    hostile_tiles.clear()
+    for c in tiles.keys():
+        if tiles[c].get("hostile", false):
+            hostile_tiles.append(c)
 

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -99,7 +99,8 @@ func _generate_tiles() -> void:
             var building: String = ""
             if q == 0 and r == 0:
                 building = "sauna"
-            _state.tiles[Vector2i(q, r)] = {
+            var coord := Vector2i(q, r)
+            _state.tiles[coord] = {
                 "terrain": terrain,
                 "owner": "none",
                 "building": building,
@@ -107,7 +108,8 @@ func _generate_tiles() -> void:
                 "hostile": is_hostile,
                 "wildlife": is_wildlife,
             }
-            _set_tile(Vector2i(q, r))
+            _state.set_hostile(coord, is_hostile)
+            _set_tile(coord)
 
 func _load_tiles() -> void:
     _ensure_singletons()

--- a/scripts/world/RaiderManager.gd
+++ b/scripts/world/RaiderManager.gd
@@ -22,22 +22,21 @@ func process_tick() -> void:
     _move_raiders()
 
 func _spawn_raiders() -> void:
-    for coord in GameState.tiles.keys():
-        var tile: Dictionary = GameState.tiles[coord]
-        if tile.get("hostile", false):
-            var target: Vector2i = _find_target(coord)
-            var path: Array[Vector2i] = Pathing.bfs_path(coord, target, func(p: Vector2i):
-                return GameState.tiles.has(p) and GameState.tiles[p].get("terrain") != "lake"
-            )
-            if path.size() >= 2:
-                var r: Node = unit_scene.instantiate()
-                r.pos_qr = coord
-                r.position = hex_map.axial_to_world(coord)
-                var vis = r.get_node_or_null("Visual")
-                if vis:
-                    vis.color = Color(0,0,0)
-                units_root.add_child(r)
-                raiders.append({"node": r, "path": path, "step": 0})
+    for coord in GameState.hostile_tiles:
+        var tile: Dictionary = GameState.tiles.get(coord, {})
+        var target: Vector2i = _find_target(coord)
+        var path: Array[Vector2i] = Pathing.bfs_path(coord, target, func(p: Vector2i):
+            return GameState.tiles.has(p) and GameState.tiles[p].get("terrain") != "lake"
+        )
+        if path.size() >= 2:
+            var r: Node = unit_scene.instantiate()
+            r.pos_qr = coord
+            r.position = hex_map.axial_to_world(coord)
+            var vis = r.get_node_or_null("Visual")
+            if vis:
+                vis.color = Color(0,0,0)
+            units_root.add_child(r)
+            raiders.append({"node": r, "path": path, "step": 0})
 
 func _move_raiders() -> void:
     for i in range(raiders.size() - 1, -1, -1):

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -107,7 +107,6 @@ func _resolve_combat(pos: Vector2i) -> void:
     if selected_unit and not ids.has(selected_unit.id):
         selected_unit = null
     tile["hostiles"] = enemy_left
-    tile["hostile"] = not enemy_left.is_empty()
     if enemy_left.is_empty() and survivors.size() > 0:
         tile["owner"] = "player"
         GameState.res[Resources.INFLUENCE] = GameState.res.get(Resources.INFLUENCE, 0.0) + 0.5
@@ -117,3 +116,4 @@ func _resolve_combat(pos: Vector2i) -> void:
     if casualties > 0:
         GameState.res[Resources.SISU] = GameState.res.get(Resources.SISU, 0.0) + casualties
     GameState.tiles[pos] = tile
+    GameState.set_hostile(pos, not enemy_left.is_empty())

--- a/tests/test_raider_spawn_performance.gd
+++ b/tests/test_raider_spawn_performance.gd
@@ -1,0 +1,41 @@
+extends Node
+
+func _setup_tiles(tile_count: int, hostile_count: int) -> void:
+    var gs = Engine.get_main_loop().root.get_node("GameState")
+    gs.tiles.clear()
+    gs.hostile_tiles.clear()
+    for i in range(tile_count):
+        var coord := Vector2i(i, 0)
+        gs.tiles[coord] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
+    for i in range(hostile_count):
+        var coord := Vector2i(i * 10, 0)
+        gs.tiles[coord]["hostile"] = true
+        gs.hostile_tiles.append(coord)
+
+func _naive_spawn_loop() -> void:
+    for coord in GameState.tiles.keys():
+        var tile: Dictionary = GameState.tiles[coord]
+        if tile.get("hostile", false):
+            pass
+
+func _optimized_spawn_loop() -> void:
+    for coord in GameState.hostile_tiles:
+        var tile: Dictionary = GameState.tiles.get(coord, {})
+        pass
+
+func test_raider_spawn_performance(res) -> void:
+    _setup_tiles(10000, 10)
+    var iterations := 50
+    var t0 := Time.get_ticks_usec()
+    for i in range(iterations):
+        _naive_spawn_loop()
+    var naive_time := Time.get_ticks_usec() - t0
+    var t1 := Time.get_ticks_usec()
+    for i in range(iterations):
+        _optimized_spawn_loop()
+    var opt_time := Time.get_ticks_usec() - t1
+    var gs = Engine.get_main_loop().root.get_node("GameState")
+    gs.tiles.clear()
+    gs.hostile_tiles.clear()
+    if opt_time * 2 >= naive_time:
+        res.fail("optimized %dus vs naive %dus" % [opt_time, naive_time])

--- a/tests/test_raiders.gd
+++ b/tests/test_raiders.gd
@@ -10,6 +10,7 @@ func _setup_world():
     gs.tiles[Vector2i(1,-1)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
     gs.tiles[Vector2i(2,0)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true, "hostile": true}
     gs.tiles[Vector2i(2,-1)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
+    gs.update_hostile_tiles()
     var world_scene: PackedScene = load("res://scenes/world/World.tscn")
     var world = world_scene.instantiate()
     tree.root.add_child(world)

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -15,6 +15,7 @@ var test_script_paths := [
     "res://tests/test_hexmap.gd",
     "res://tests/test_pathing.gd",
     "res://tests/test_bfs_performance.gd",
+    "res://tests/test_raider_spawn_performance.gd",
     "res://tests/test_action.gd",
     "res://tests/test_resources.gd",
     "res://tests/test_prestige.gd",


### PR DESCRIPTION
## Summary
- track hostile tile coordinates in GameState and keep list updated
- spawn raiders only from cached hostile tiles to avoid full-map scans
- add performance test for hostile-based spawn iteration

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: Could not resolve script "res://scripts/policies/Policy.gd" and other parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1938604c08330a904d8a86a9e447e