### PR TITLE
Handle events whose apply returns false

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -44,7 +44,12 @@ func start_event(ev: GameEvent) -> void:
         return
     current_event = ev
     if ev.has_method("apply"):
-        ev.apply()
+        var ok := ev.apply()
+        if not ok:
+            current_event = null
+            GameClock.start()
+            _schedule_next_event()
+            return
     GameClock.stop()
     var overlay = OVERLAY_SCENE.instantiate()
     overlay.show_event(ev)

--- a/tests/test_events.gd
+++ b/tests/test_events.gd
@@ -3,6 +3,11 @@ var Resources = preload("res://scripts/core/Resources.gd")
 var GameEvent = preload("res://scripts/events/Event.gd")
 var ColdSnapEvent = preload("res://scripts/events/ColdSnap.gd")
 
+class DummyEvent:
+    extends GameEvent
+    func apply() -> bool:
+        return false
+
 func _cleanup_overlays(tree):
     for child in tree.root.get_children():
         if child.name == "EventOverlay":
@@ -86,4 +91,21 @@ func test_event_fails_prerequisites(res) -> void:
     gs.res = orig
     if em.current_event != null or overlay_present:
         res.fail("event started despite failing prerequisites")
+
+func test_apply_returns_false(res) -> void:
+    var tree = Engine.get_main_loop()
+    var em = tree.root.get_node("EventManager")
+    var clock = tree.root.get_node("GameClock")
+    clock.start()
+    var ev: DummyEvent = DummyEvent.new()
+    em.start_event(ev)
+    var overlay_present := false
+    for child in tree.root.get_children():
+        if child.name == "EventOverlay":
+            overlay_present = true
+    _cleanup_overlays(tree)
+    if overlay_present or em.current_event != null:
+        res.fail("event started despite apply returning false")
+    if not clock.running:
+        res.fail("GameClock stopped on failed event")
         


### PR DESCRIPTION
## Summary
- Exit early in EventManager when an event's apply() returns false and reschedule clock
- Add test ensuring events that abort in apply() don't show overlay or pause clock

## Testing
- `godot3-server -s tests/test_runner.gd` *(fails: Can't open project, requires newer Godot version)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux_headless.64.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c19505ea2883308b077b86b192f1ad