### PR TITLE
Track hostile tiles and optimize raider spawning

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -29,6 +29,7 @@ var last_timestamp: int = 0
 var tiles: Dictionary = {}
 var units: Array = []
 var tutorial_done: bool = false
+var hostile_tiles: Array = []
 
 const SAVE_PATH := "user://save.json"
 
@@ -90,12 +91,15 @@ func load_state() -> void:
     tutorial_done = bool(data.get("tutorial_done", false))
     last_timestamp = int(data.get("last_timestamp", Time.get_unix_time_from_system()))
     tiles.clear()
+    hostile_tiles.clear()
     var tile_data: Dictionary = data.get("tiles", {})
     for key in tile_data.keys():
         var parts: PackedStringArray = key.split(",")
         if parts.size() == 2:
             var c := Vector2i(int(parts[0]), int(parts[1]))
             tiles[c] = tile_data[key]
+            if tiles[c].get("hostile", false):
+                hostile_tiles.append(c)
     units.clear()
     for u in data.get("units", []):
         var pos_arr: Array = u.get("pos_qr", [0, 0])
@@ -139,4 +143,13 @@ func prestige() -> void:
 func _apply_speed_for_prestige() -> void:
     var prestige_level: int = int(res.get(Resources.PRESTIGE, 0))
     GameClock.set_speed(1.0 + prestige_level * SPEED_PER_PRESTIGE)
+
+func set_hostile_tile(coord: Vector2i, hostile: bool) -> void:
+    if hostile:
+        if coord not in hostile_tiles:
+            hostile_tiles.append(coord)
+    else:
+        hostile_tiles.erase(coord)
+    if tiles.has(coord):
+        tiles[coord]["hostile"] = hostile
 

--- a/scripts/policies/Policy.gd
+++ b/scripts/policies/Policy.gd
@@ -1,4 +1,4 @@
-extends Action
+extends "res://scripts/core/Action.gd"
 class_name Policy
 
 @export var name: String = ""

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -17,7 +17,7 @@ var _state: Node
 var _rng: Node
 
 func _ensure_singletons() -> void:
-    var root := Engine.get_main_loop().root
+    var root = Engine.get_main_loop().root
     if _state == null:
         _state = root.get_node("GameState")
     if _rng == null:
@@ -99,7 +99,8 @@ func _generate_tiles() -> void:
             var building: String = ""
             if q == 0 and r == 0:
                 building = "sauna"
-            _state.tiles[Vector2i(q, r)] = {
+            var coord := Vector2i(q, r)
+            _state.tiles[coord] = {
                 "terrain": terrain,
                 "owner": "none",
                 "building": building,
@@ -107,7 +108,8 @@ func _generate_tiles() -> void:
                 "hostile": is_hostile,
                 "wildlife": is_wildlife,
             }
-            _set_tile(Vector2i(q, r))
+            _state.set_hostile_tile(coord, is_hostile)
+            _set_tile(coord)
 
 func _load_tiles() -> void:
     _ensure_singletons()

--- a/scripts/world/RaiderManager.gd
+++ b/scripts/world/RaiderManager.gd
@@ -22,8 +22,8 @@ func process_tick() -> void:
     _move_raiders()
 
 func _spawn_raiders() -> void:
-    for coord in GameState.tiles.keys():
-        var tile: Dictionary = GameState.tiles[coord]
+    for coord in GameState.hostile_tiles:
+        var tile: Dictionary = GameState.tiles.get(coord, {})
         if tile.get("hostile", false):
             var target: Vector2i = _find_target(coord)
             var path: Array[Vector2i] = Pathing.bfs_path(coord, target, func(p: Vector2i):

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -107,8 +107,8 @@ func _resolve_combat(pos: Vector2i) -> void:
     if selected_unit and not ids.has(selected_unit.id):
         selected_unit = null
     tile["hostiles"] = enemy_left
-    tile["hostile"] = not enemy_left.is_empty()
-    if enemy_left.is_empty() and survivors.size() > 0:
+    var is_hostile := not enemy_left.is_empty()
+    if not is_hostile and survivors.size() > 0:
         tile["owner"] = "player"
         GameState.res[Resources.INFLUENCE] = GameState.res.get(Resources.INFLUENCE, 0.0) + 0.5
     elif survivors.is_empty():
@@ -117,3 +117,4 @@ func _resolve_combat(pos: Vector2i) -> void:
     if casualties > 0:
         GameState.res[Resources.SISU] = GameState.res.get(Resources.SISU, 0.0) + casualties
     GameState.tiles[pos] = tile
+    GameState.set_hostile_tile(pos, is_hostile)

--- a/tests/test_action.gd
+++ b/tests/test_action.gd
@@ -1,8 +1,8 @@
 extends Node
 
-var Action = preload("res://scripts/core/Action.gd")
-var Policy = preload("res://scripts/policies/Policy.gd")
-var GameEvent = preload("res://scripts/events/Event.gd")
+const Action = preload("res://scripts/core/Action.gd")
+const Policy = preload("res://scripts/policies/Policy.gd")
+const GameEvent = preload("res://scripts/events/Event.gd")
 var Resources = preload("res://scripts/core/Resources.gd")
 
 func test_policy_apply_and_cooldown(res):
@@ -31,7 +31,7 @@ func test_event_inherits_action(res):
     gs.res[Resources.GOLD] = 100.0
     gs.res[Resources.MORALE] = 0.0
     gs.res[Resources.FOOD] = 0.0
-    var ev: GameEvent = load("res://resources/events/rain.tres")
+    var ev = load("res://resources/events/rain.tres") as GameEvent
     if not (ev is Action):
         res.fail("Event does not inherit Action")
         return
@@ -53,7 +53,7 @@ func test_sauna_diplomacy(res):
     gs.res[Resources.WOOD] = 50.0
     gs.res[Resources.LOYLY] = 1.0
     gs.res[Resources.INFLUENCE] = 0.0
-    var ev: GameEvent = load("res://resources/events/sauna_diplomacy.tres")
+    var ev = load("res://resources/events/sauna_diplomacy.tres") as GameEvent
     if not ev.can_trigger():
         res.fail("Sauna Diplomacy cannot trigger")
         gs.res = orig_res

--- a/tests/test_battle.gd
+++ b/tests/test_battle.gd
@@ -13,6 +13,7 @@ func test_battle_player_win(res) -> void:
     var orig = gs.res.duplicate()
     gs.units.clear()
     gs.tiles.clear()
+    gs.hostile_tiles.clear()
     var world_scene: PackedScene = load("res://scenes/world/World.tscn")
     var world = world_scene.instantiate()
     tree.root.add_child(world)
@@ -33,6 +34,7 @@ func test_battle_player_win(res) -> void:
     gs.res = orig
     gs.units.clear()
     gs.tiles.clear()
+    gs.hostile_tiles.clear()
     _remove_save(gs)
 
 func test_battle_player_loss(res) -> void:
@@ -42,6 +44,7 @@ func test_battle_player_loss(res) -> void:
     var orig = gs.res.duplicate()
     gs.units.clear()
     gs.tiles.clear()
+    gs.hostile_tiles.clear()
     var world_scene: PackedScene = load("res://scenes/world/World.tscn")
     var world = world_scene.instantiate()
     tree.root.add_child(world)
@@ -66,4 +69,5 @@ func test_battle_player_loss(res) -> void:
     gs.res = orig
     gs.units.clear()
     gs.tiles.clear()
+    gs.hostile_tiles.clear()
     _remove_save(gs)

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -19,6 +19,7 @@ func _reset_tiles() -> void:
     var tree = Engine.get_main_loop()
     var gs = tree.root.get_node("GameState")
     gs.tiles.clear()
+    gs.hostile_tiles.clear()
 
 func _remove_save(gs) -> void:
     if FileAccess.file_exists(gs.SAVE_PATH):
@@ -88,6 +89,7 @@ func test_tiles_persist_across_save(res) -> void:
     gs.save()
     var before := JSON.stringify(gs.tiles)
     gs.tiles.clear()
+    gs.hostile_tiles.clear()
     gs.load()
     var after := JSON.stringify(gs.tiles)
     if before != after:

--- a/tests/test_raider_spawn_performance.gd
+++ b/tests/test_raider_spawn_performance.gd
@@ -1,0 +1,46 @@
+extends Node
+
+func _setup_tiles(count: int, hostiles: int) -> void:
+    var gs = Engine.get_main_loop().root.get_node("GameState")
+    gs.tiles.clear()
+    gs.hostile_tiles.clear()
+    for i in range(count):
+        var c := Vector2i(i, 0)
+        gs.tiles[c] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
+    for i in range(hostiles):
+        var coord := Vector2i(i * 10, 0)
+        gs.tiles[coord]["hostile"] = true
+        gs.set_hostile_tile(coord, true)
+
+func _old_iter(gs) -> int:
+    var cnt := 0
+    for coord in gs.tiles.keys():
+        var tile = gs.tiles[coord]
+        if tile.get("hostile", false):
+            cnt += 1
+    return cnt
+
+func _new_iter(gs) -> int:
+    var cnt := 0
+    for coord in gs.hostile_tiles:
+        var tile = gs.tiles.get(coord, {})
+        if tile.get("hostile", false):
+            cnt += 1
+    return cnt
+
+func test_raider_spawn_performance(res) -> void:
+    var gs = Engine.get_main_loop().root.get_node("GameState")
+    _setup_tiles(100000, 100)
+    var iterations := 5
+    var old_time := 0
+    for i in range(iterations):
+        var t0 := Time.get_ticks_usec()
+        _old_iter(gs)
+        old_time += Time.get_ticks_usec() - t0
+    var new_time := 0
+    for i in range(iterations):
+        var t1 := Time.get_ticks_usec()
+        _new_iter(gs)
+        new_time += Time.get_ticks_usec() - t1
+    if new_time * 5 >= old_time:
+        res.fail("new iteration %dus vs old %dus" % [new_time, old_time])

--- a/tests/test_raiders.gd
+++ b/tests/test_raiders.gd
@@ -5,10 +5,12 @@ func _setup_world():
     var gs = tree.root.get_node("GameState")
     gs.units.clear()
     gs.tiles.clear()
+    gs.hostile_tiles.clear()
     gs.tiles[Vector2i(0,0)] = {"terrain": "forest", "owner": "player", "building": null, "explored": true}
     gs.tiles[Vector2i(1,0)] = {"terrain": "lake", "owner": "none", "building": null, "explored": true}
     gs.tiles[Vector2i(1,-1)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
     gs.tiles[Vector2i(2,0)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true, "hostile": true}
+    gs.set_hostile_tile(Vector2i(2,0), true)
     gs.tiles[Vector2i(2,-1)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
     var world_scene: PackedScene = load("res://scenes/world/World.tscn")
     var world = world_scene.instantiate()

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -15,6 +15,7 @@ var test_script_paths := [
     "res://tests/test_hexmap.gd",
     "res://tests/test_pathing.gd",
     "res://tests/test_bfs_performance.gd",
+    "res://tests/test_raider_spawn_performance.gd",
     "res://tests/test_action.gd",
     "res://tests/test_resources.gd",
     "res://tests/test_prestige.gd",

--- a/tests/test_world.gd
+++ b/tests/test_world.gd
@@ -10,6 +10,7 @@ func test_spawn_and_reveal(res) -> void:
     _remove_save(gs)
     gs.units.clear()
     gs.tiles.clear()
+    gs.hostile_tiles.clear()
     var world_scene: PackedScene = load("res://scenes/world/World.tscn")
     var world = world_scene.instantiate()
     tree.root.add_child(world)
@@ -31,4 +32,5 @@ func test_spawn_and_reveal(res) -> void:
     world.queue_free()
     gs.units.clear()
     gs.tiles.clear()
+    gs.hostile_tiles.clear()
     _remove_save(gs)


### PR DESCRIPTION
## Summary
- Maintain a `hostile_tiles` list in `GameState` and update it when hostility changes
- Spawn raiders by iterating only over hostile tiles instead of the full map
- Add a performance test comparing hostile list iteration with full map scan

## Testing
- `godot --headless --path . --script tests/test_runner.gd` *(fails: Index p_layer = 2 is out of bounds and additional parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c19508d89c8330a3dbf68feeba5ed6