### PR TITLE
Optimize raider spawn using hostile tile tracking

### DIFF
--- a/tests/test_raider_spawn_performance.gd
+++ b/tests/test_raider_spawn_performance.gd
@@ -9,8 +9,7 @@ func _setup_tiles(tile_count: int, hostile_count: int) -> void:
         gs.tiles[coord] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
     for i in range(hostile_count):
         var coord := Vector2i(i * 10, 0)
-        gs.tiles[coord]["hostile"] = true
-        gs.hostile_tiles.append(coord)
+        gs.set_hostile(coord, true)
 
 func _naive_spawn_loop() -> void:
     for coord in GameState.tiles.keys():

--- a/tests/test_raiders.gd
+++ b/tests/test_raiders.gd
@@ -8,9 +8,9 @@ func _setup_world():
     gs.tiles[Vector2i(0,0)] = {"terrain": "forest", "owner": "player", "building": null, "explored": true}
     gs.tiles[Vector2i(1,0)] = {"terrain": "lake", "owner": "none", "building": null, "explored": true}
     gs.tiles[Vector2i(1,-1)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
-    gs.tiles[Vector2i(2,0)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true, "hostile": true}
+    gs.tiles[Vector2i(2,0)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
     gs.tiles[Vector2i(2,-1)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
-    gs.update_hostile_tiles()
+    gs.set_hostile(Vector2i(2,0), true)
     var world_scene: PackedScene = load("res://scenes/world/World.tscn")
     var world = world_scene.instantiate()
     tree.root.add_child(world)


### PR DESCRIPTION
## Summary
- Track hostile tile positions in `GameState` and expose a helper to update the list when hostility changes
- Spawn raiders only from tracked hostile tiles for faster spawning
- Add performance regression test for raider spawning and update tests to use `GameState.set_hostile`

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `godot3-server --path . -s tests/test_runner.gd` *(fails: project uses newer config version)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a314e264833098a7a3ff83f932d4