### PR TITLE
Handle failed event apply

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -43,8 +43,14 @@ func start_event(ev: GameEvent) -> void:
     if not ev.can_trigger():
         return
     current_event = ev
+    var applied := true
     if ev.has_method("apply"):
-        ev.apply()
+        applied = ev.apply()
+    if not applied:
+        current_event = null
+        GameClock.start()
+        _schedule_next_event()
+        return
     GameClock.stop()
     var overlay = OVERLAY_SCENE.instantiate()
     overlay.show_event(ev)

--- a/tests/test_events.gd
+++ b/tests/test_events.gd
@@ -3,6 +3,10 @@ var Resources = preload("res://scripts/core/Resources.gd")
 var GameEvent = preload("res://scripts/events/Event.gd")
 var ColdSnapEvent = preload("res://scripts/events/ColdSnap.gd")
 
+class DummyEvent extends GameEvent:
+    func apply() -> bool:
+        return false
+
 func _cleanup_overlays(tree):
     for child in tree.root.get_children():
         if child.name == "EventOverlay":
@@ -105,5 +109,26 @@ func test_unaffordable_choice_keeps_resources(res) -> void:
     gs.res = orig
     em.current_event = null
     clock.start()
+    clock.set_process(true)
+
+func test_event_apply_returns_false(res) -> void:
+    var tree = Engine.get_main_loop()
+    var em = tree.root.get_node("EventManager")
+    var clock = tree.root.get_node("GameClock")
+    clock.set_process(false)
+    clock.start()
+    var ev: DummyEvent = DummyEvent.new()
+    em.start_event(ev)
+    var overlay_present := false
+    for child in tree.root.get_children():
+        if child.name == "EventOverlay":
+            overlay_present = true
+    _cleanup_overlays(tree)
+    if overlay_present:
+        res.fail("overlay shown despite apply returning false")
+    if em.current_event != null:
+        res.fail("current_event not cleared after apply returned false")
+    if not clock.running:
+        res.fail("GameClock stopped despite apply returning false")
     clock.set_process(true)
         


### PR DESCRIPTION
## Summary
- Avoid showing event overlay when an event's apply returns false
- Add regression test for events that fail during apply

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `godot3 --headless -s tests/test_runner.gd` *(fails: project requires newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a62e8f5c8330a0a9a65a8239681f