### PR TITLE
Improve raider targeting logic

### DIFF
--- a/scripts/world/RaiderManager.gd
+++ b/scripts/world/RaiderManager.gd
@@ -56,13 +56,21 @@ func _move_raiders() -> void:
             raiders.remove_at(i)
 
 func _find_target(start: Vector2i) -> Vector2i:
+    var candidates: Array[Vector2i] = []
+    for u in GameState.units:
+        candidates.append(u.get("pos_qr", Vector2i.ZERO))
+    if candidates.is_empty():
+        for coord in GameState.tiles.keys():
+            var tile: Dictionary = GameState.tiles[coord]
+            if tile.get("owner", "") == "player" and tile.get("building") != null:
+                candidates.append(coord)
+    if candidates.is_empty():
+        return Vector2i.ZERO
     var best := Vector2i.ZERO
-    var best_dist := HexUtils.axial_distance(start, Vector2i.ZERO)
-    for coord in GameState.tiles.keys():
-        var tile: Dictionary = GameState.tiles[coord]
-        if tile.get("owner", "") == "player" and tile.get("building") != null:
-            var dist := HexUtils.axial_distance(start, coord)
-            if dist < best_dist:
-                best_dist = dist
-                best = coord
+    var best_dist := INF
+    for coord in candidates:
+        var dist := HexUtils.axial_distance(start, coord)
+        if dist < best_dist:
+            best_dist = dist
+            best = coord
     return best

--- a/tests/test_raiders.gd
+++ b/tests/test_raiders.gd
@@ -43,3 +43,25 @@ func test_raider_spawn_and_path(res) -> void:
     if raider.pos_qr != Vector2i(0,0):
         res.fail("raider did not reach center")
     world.queue_free()
+
+func test_target_prefers_nearest_building(res) -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    gs.units.clear()
+    gs.tiles.clear()
+    gs.tiles[Vector2i(3,-1)] = {"terrain": "forest", "owner": "player", "building": "farm"}
+    gs.tiles[Vector2i(0,0)] = {"terrain": "forest", "owner": "player", "building": "sauna"}
+    var rm = load("res://scripts/world/RaiderManager.gd").new()
+    var target = rm._find_target(Vector2i(6,-3))
+    if target != Vector2i(3,-1):
+        res.fail("expected (3,-1) got %s" % target)
+
+func test_target_falls_back_to_center(res) -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    gs.units.clear()
+    gs.tiles.clear()
+    var rm = load("res://scripts/world/RaiderManager.gd").new()
+    var target = rm._find_target(Vector2i(6,-3))
+    if target != Vector2i.ZERO:
+        res.fail("expected (0,0) got %s" % target)


### PR DESCRIPTION
## Summary
- Target nearest player unit or building before defaulting to origin
- Test raider targeting with and without player presence

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project, engine version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a6c1cf10833097ca9350a1d03d7a