### PR TITLE
Persist hex map and building data across save/load

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -7,6 +7,7 @@ const SPEED_PER_PRESTIGE := 0.25
 
 const Resources = preload("res://scripts/core/Resources.gd")
 const Prestige = preload("res://scripts/core/Prestige.gd")
+const Building = preload("res://scripts/core/Building.gd")
 
 var res := {
     Resources.WOOD: 0.0,
@@ -51,7 +52,12 @@ func save() -> void:
     last_timestamp = Time.get_unix_time_from_system()
     var tile_data: Dictionary = {}
     for c in tiles.keys():
-        tile_data["%d,%d" % [c.x, c.y]] = tiles[c]
+        var t: Dictionary = tiles[c]
+        var b = t.get("building", null)
+        if b is Building:
+            t = t.duplicate()
+            t["building"] = b.resource_path.get_file().get_basename()
+        tile_data["%d,%d" % [c.x, c.y]] = t
     var unit_data: Array = []
     for u in units:
         unit_data.append({

--- a/scripts/ui/Main.gd
+++ b/scripts/ui/Main.gd
@@ -51,7 +51,7 @@ func _on_build_pressed() -> void:
             return
     for res in cost.keys():
         GameState.res[res] = GameState.res.get(res, 0.0) - cost[res]
-    tile["building"] = _selected_building
+    tile["building"] = _selected_building.resource_path.get_file().get_basename()
     GameState.tiles[_last_clicked] = tile
     hud.update_tile(_last_clicked, _selected_building)
     hud.update_resources(GameState.res)
@@ -59,7 +59,8 @@ func _on_build_pressed() -> void:
 func _on_tile_clicked(qr: Vector2i) -> void:
     _last_clicked = qr
     var data: Dictionary = GameState.tiles.get(qr, {})
-    var building = data.get("building", null)
+    var bname = data.get("building", "")
+    var building = _buildings.get(bname, null)
     hud.update_tile(qr, building)
     hud.show_building_info(building)
     print("Main: clicked %s terrain %s" % [qr, data.get("terrain", "")])

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -35,7 +35,7 @@ func _ready() -> void:
         _generate_tiles()
         reveal_area(Vector2i.ZERO, 2)
     else:
-        _load_tiles()
+        _draw_from_saved(_state.tiles)
 
 func _setup_tileset() -> void:
     if tile_set == null:
@@ -111,9 +111,9 @@ func _generate_tiles() -> void:
             _state.set_hostile(coord, is_hostile)
             _set_tile(coord)
 
-func _load_tiles() -> void:
+func _draw_from_saved(tiles: Dictionary) -> void:
     _ensure_singletons()
-    for coord in _state.tiles.keys():
+    for coord in tiles.keys():
         _set_tile(coord)
 
 func _set_tile(coord: Vector2i) -> void:

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -94,3 +94,21 @@ func test_tiles_persist_across_save(res) -> void:
         res.fail("tiles did not persist across save/load")
     _remove_save(gs)
 
+func test_buildings_persist_across_save(res) -> void:
+    _reset_tiles()
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    var map = DummyHexMap.new()
+    map.radius = 1
+    map.terrain_weights = {"forest": 1.0}
+    map._generate_tiles()
+    gs.tiles[Vector2i(0,0)]["building"] = preload("res://resources/buildings/farm.tres")
+    _remove_save(gs)
+    gs.save()
+    gs.tiles.clear()
+    gs.load()
+    var loaded = gs.tiles.get(Vector2i(0,0), {}).get("building", "")
+    if loaded != "farm":
+        res.fail("building did not persist across save/load")
+    _remove_save(gs)
+


### PR DESCRIPTION
## Summary
- avoid regenerating map when GameState already has tiles and draw from saved data
- save building names so map, buildings, and units persist across loads
- test that building information survives save/load cycle

## Testing
- `godot3-server --headless tests/test_runner.gd` *(fails: Can't open project at '/workspace/finsim_AA-club/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine. Expected config version: 4.)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a8bd44208330be0ef87c6f4b9b79