### PR TITLE
Implement Sisu heal action and morale penalties

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -88,6 +88,8 @@ func load_state() -> void:
         last_timestamp = Time.get_unix_time_from_system()
         return
     res = data.get("res", res)
+    res[Resources.SISU] = min(10.0, res.get(Resources.SISU, 0.0))
+    res[Resources.MORALE] = max(0.0, res.get(Resources.MORALE, 0.0))
     tutorial_done = bool(data.get("tutorial_done", false))
     last_timestamp = int(data.get("last_timestamp", Time.get_unix_time_from_system()))
     tiles.clear()
@@ -164,4 +166,12 @@ func update_hostile_tiles() -> void:
     for c in tiles.keys():
         if tiles[c].get("hostile", false):
             hostile_tiles.append(c)
+
+func add_sisu(amount: float) -> void:
+    var current: float = res.get(Resources.SISU, 0.0)
+    res[Resources.SISU] = min(10.0, current + amount)
+
+func decrease_morale(amount: float) -> void:
+    var current: float = res.get(Resources.MORALE, 0.0)
+    res[Resources.MORALE] = max(0.0, current - amount)
 

--- a/scenes/ui/Main.tscn
+++ b/scenes/ui/Main.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=5]
+[gd_scene load_steps=6]
 
 [ext_resource path="res://scenes/ui/Hud.tscn" type="PackedScene" id="1"]
 [ext_resource path="res://scenes/world/World.tscn" type="PackedScene" id="2"]
 [ext_resource path="res://scripts/ui/Main.gd" type="Script" id="3"]
 
 [ext_resource path="res://resources/GrainNoise.tres" type="Texture2D" id="4"]
+[ext_resource path="res://scripts/systems/SisuSystem.gd" type="Script" id="5"]
 
 [node name="Main" type="Node"]
 script = ExtResource("3")
@@ -12,6 +13,9 @@ script = ExtResource("3")
 [node name="World" parent="." instance=ExtResource("2")]
 
 [node name="Hud" parent="." instance=ExtResource("1")]
+
+[node name="SisuSystem" type="Node" parent="."]
+script = ExtResource("5")
 
 [node name="GrainOverlay" type="CanvasLayer" parent="."]
 layer = 1
@@ -37,4 +41,9 @@ text = "Reveal All"
 [node name="SpawnButton" type="Button" parent="DebugUI"]
 position = Vector2(0,30)
 text = "Spawn Conscript at Center"
+
+[node name="SpendSisuButton" type="Button" parent="DebugUI"]
+position = Vector2(0,60)
+text = "Spend Sisu"
+tooltip_text = "Heal team 20% (5 Sisu, 10s cd)"
 

--- a/scripts/systems/SisuSystem.gd
+++ b/scripts/systems/SisuSystem.gd
@@ -1,0 +1,49 @@
+extends Node
+
+const Resources = preload("res://scripts/core/Resources.gd")
+
+const COOLDOWN_TICKS := 20 # 10 seconds at 0.5s per tick
+
+var cooldown_ticks_remaining: int = 0
+var world: Node = null
+
+func _ready() -> void:
+    GameClock.tick.connect(_on_tick)
+
+func _on_tick() -> void:
+    if cooldown_ticks_remaining > 0:
+        cooldown_ticks_remaining -= 1
+
+func can_spend() -> bool:
+    return cooldown_ticks_remaining <= 0 and GameState.res.get(Resources.SISU, 0.0) >= 5.0
+
+func spend() -> bool:
+    if not can_spend():
+        return false
+    GameState.res[Resources.SISU] = GameState.res.get(Resources.SISU, 0.0) - 5.0
+    cooldown_ticks_remaining = COOLDOWN_TICKS
+    _heal_units()
+    return true
+
+func _heal_units() -> void:
+    var nodes_by_id: Dictionary = {}
+    if world and world.has_node("Units"):
+        for child in world.units_root.get_children():
+            nodes_by_id[child.id] = child
+    for i in range(GameState.units.size()):
+        var data: Dictionary = GameState.units[i]
+        var uid: String = data.get("id", "")
+        var hp: int = data.get("hp", 0)
+        var max_hp: int = hp
+        var path: String = data.get("data_path", "")
+        if path != "":
+            var ud = load(path)
+            if ud:
+                max_hp = int(ud.max_health)
+        var heal_amount: int = int(max_hp * 0.2)
+        hp = min(max_hp, hp + heal_amount)
+        data["hp"] = hp
+        GameState.units[i] = data
+        if nodes_by_id.has(uid):
+            var node = nodes_by_id[uid]
+            node.hp = hp

--- a/scripts/ui/Main.gd
+++ b/scripts/ui/Main.gd
@@ -7,6 +7,8 @@ const TutorialOverlay = preload("res://scenes/ui/TutorialOverlay.tscn")
 @onready var hud: CanvasLayer = $Hud
 @onready var reveal_btn: Button = $DebugUI/RevealAllButton
 @onready var spawn_btn: Button = $DebugUI/SpawnButton
+@onready var sisu_btn: Button = $DebugUI/SpendSisuButton
+@onready var sisu_system: Node = $SisuSystem
 
 var _selected_building: Building = null
 var _last_clicked: Vector2i = Vector2i.ZERO
@@ -27,12 +29,16 @@ func _ready() -> void:
     GameClock.tick.connect(_on_game_tick)
     reveal_btn.pressed.connect(_on_reveal_all)
     spawn_btn.pressed.connect(_on_spawn)
+    sisu_btn.pressed.connect(_on_sisu_pressed)
+    sisu_system.world = world
     hud.update_resources(GameState.res)
+    _update_sisu_button()
     if not GameState.tutorial_done:
         start_tutorial()
 
 func _on_game_tick() -> void:
     hud.update_resources(GameState.res)
+    _update_sisu_button()
 
 func _on_building_selected(name: String) -> void:
     _selected_building = _buildings.get(name, null)
@@ -69,6 +75,14 @@ func _on_reveal_all() -> void:
 
 func _on_spawn() -> void:
     world.spawn_unit_at_center()
+
+func _on_sisu_pressed() -> void:
+    if sisu_system.spend():
+        hud.update_resources(GameState.res)
+    _update_sisu_button()
+
+func _update_sisu_button() -> void:
+    sisu_btn.disabled = not sisu_system.can_spend()
 
 func start_tutorial() -> void:
     if _tutorial_overlay:

--- a/scripts/world/RaiderManager.gd
+++ b/scripts/world/RaiderManager.gd
@@ -49,11 +49,29 @@ func _move_raiders() -> void:
             var next: Vector2i = path[step]
             node.pos_qr = next
             node.position = hex_map.axial_to_world(next)
-            data["step"] = step
-            raiders[i] = data
+            if step >= path.size() - 1:
+                _raider_reached(node)
+                node.queue_free()
+                raiders.remove_at(i)
+            else:
+                data["step"] = step
+                raiders[i] = data
         else:
+            _raider_reached(node)
             node.queue_free()
             raiders.remove_at(i)
+
+func _raider_reached(node) -> void:
+    var tile: Dictionary = GameState.tiles.get(node.pos_qr, {})
+    var hit := false
+    if tile.get("owner", "") == "player":
+        GameState.decrease_morale(1.0)
+        hit = true
+        tile["owner"] = "enemy"
+        GameState.tiles[node.pos_qr] = tile
+        GameState.set_hostile(node.pos_qr, true)
+    if node.pos_qr == Vector2i.ZERO and not hit:
+        GameState.decrease_morale(1.0)
 
 func _find_target(start: Vector2i) -> Vector2i:
     var candidates: Array[Vector2i] = []

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -111,9 +111,9 @@ func _resolve_combat(pos: Vector2i) -> void:
         tile["owner"] = "player"
         GameState.res[Resources.INFLUENCE] = GameState.res.get(Resources.INFLUENCE, 0.0) + 0.5
     elif survivors.is_empty():
-        GameState.res[Resources.MORALE] = GameState.res.get(Resources.MORALE, 0.0) - 1.0
+        GameState.decrease_morale(1.0)
     var casualties := initial - survivors.size()
     if casualties > 0:
-        GameState.res[Resources.SISU] = GameState.res.get(Resources.SISU, 0.0) + casualties
+        GameState.add_sisu(casualties)
     GameState.tiles[pos] = tile
     GameState.set_hostile(pos, not enemy_left.is_empty())

--- a/tests/test_raiders.gd
+++ b/tests/test_raiders.gd
@@ -1,5 +1,7 @@
 extends Node
 
+var Resources = preload("res://scripts/core/Resources.gd")
+
 func _setup_world():
     var tree = Engine.get_main_loop()
     var gs = tree.root.get_node("GameState")
@@ -65,3 +67,21 @@ func test_target_falls_back_to_center(res) -> void:
     var target = rm._find_target(Vector2i(6,-3))
     if target != Vector2i.ZERO:
         res.fail("expected (0,0) got %s" % target)
+
+func test_raider_morale_hit(res) -> void:
+    var world = _setup_world()
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    var orig = gs.res.duplicate()
+    for i in range(19):
+        world._on_game_tick()
+    world._on_game_tick()
+    world._on_game_tick()
+    world._on_game_tick()
+    var expected = max(0.0, orig.get(Resources.MORALE, 0.0) - 1.0)
+    if abs(gs.res[Resources.MORALE] - expected) > 0.01:
+        res.fail("Morale not reduced on raider success")
+    world.queue_free()
+    gs.res = orig
+    gs.units.clear()
+    gs.tiles.clear()

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -23,6 +23,7 @@ var test_script_paths := [
     "res://tests/test_world.gd",
     "res://tests/test_battle.gd",
     "res://tests/test_raiders.gd",
+    "res://tests/test_sisu.gd",
 ]
 
 func _init() -> void:

--- a/tests/test_sisu.gd
+++ b/tests/test_sisu.gd
@@ -1,0 +1,56 @@
+extends Node
+
+var Resources = preload("res://scripts/core/Resources.gd")
+
+func _remove_save(gs) -> void:
+    if FileAccess.file_exists(gs.SAVE_PATH):
+        DirAccess.remove_absolute(gs.SAVE_PATH)
+
+func _cleanup(world, sisu, gs, orig) -> void:
+    world.queue_free()
+    sisu.queue_free()
+    gs.res = orig
+    gs.units.clear()
+    gs.tiles.clear()
+    _remove_save(gs)
+
+func test_spend_sisu_heals(res) -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    _remove_save(gs)
+    var orig = gs.res.duplicate()
+    gs.units.clear()
+    gs.tiles.clear()
+    var world_scene: PackedScene = load("res://scenes/world/World.tscn")
+    var world = world_scene.instantiate()
+    tree.root.add_child(world)
+    for i in range(3):
+        world.spawn_unit_at_center()
+        var unit = world.units_root.get_child(i)
+        unit.hp = int(unit.unit_data.max_health * 0.5)
+        gs.units[i]["hp"] = unit.hp
+    gs.res[Resources.SISU] = 5.0
+    var SisuSystem = load("res://scripts/systems/SisuSystem.gd")
+    var sisu = SisuSystem.new()
+    sisu.world = world
+    tree.root.add_child(sisu)
+    if not sisu.spend():
+        res.fail("Spend failed")
+        _cleanup(world, sisu, gs, orig)
+        return
+    for unit in world.units_root.get_children():
+        var max_hp = unit.unit_data.max_health
+        var expected = int(max_hp * 0.7)
+        if unit.hp != expected:
+            res.fail("Unit not healed")
+            _cleanup(world, sisu, gs, orig)
+            return
+    if gs.res[Resources.SISU] != 0.0:
+        res.fail("Sisu not deducted")
+        _cleanup(world, sisu, gs, orig)
+        return
+    if sisu.cooldown_ticks_remaining <= 0:
+        res.fail("Cooldown not active")
+        _cleanup(world, sisu, gs, orig)
+        return
+    _cleanup(world, sisu, gs, orig)


### PR DESCRIPTION
## Summary
- Cap Sisu at 10 and add helpers for Sisu and Morale handling
- Wire up Sisu heal ability with cooldown and UI button
- Decrease morale when raiders succeed and add tests for Sisu heal and raider morale hit

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: Could not resolve class "HexMap")*


------
https://chatgpt.com/codex/tasks/task_e_68c1a85867848330853eb6abff2adae4