### PR TITLE
feat: start with initial gold

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -18,7 +18,7 @@ var res := {
     Resources.LOYLY: 0.0,
     Resources.SISU: 0.0,
     Resources.MORALE: 100.0,
-    Resources.GOLD: 0.0,
+    Resources.GOLD: 100.0,
     Resources.PRESTIGE: 0.0,
 }
 

--- a/tests/test_resources.gd
+++ b/tests/test_resources.gd
@@ -20,3 +20,8 @@ func test_game_state_resources(res) -> void:
     expected.sort()
     if keys != expected:
         res.fail("resource keys mismatch: %s" % [keys])
+
+func test_starting_gold(res) -> void:
+    var gs = Engine.get_main_loop().root.get_node("GameState")
+    if gs.res[Resources.GOLD] <= 0.0:
+        res.fail("starting gold should be positive")


### PR DESCRIPTION
## Summary
- seed starting resources with gold so early structures can be built
- test that a new game begins with some gold

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1abe75ea48330bf6c98b1233ff3ff