### PR TITLE
refactor: use TileMapLayer nodes

### DIFF
--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -9,17 +9,19 @@
 [node name="World" type="Node2D"]
 script = ExtResource("1")
 
-[node name="TileMap" type="TileMap" parent="."]
-tile_set = ExtResource("2")
-cell_tile_size = Vector2i(96, 84)
+[node name="HexMap" type="Node2D" parent="."]
 script = ExtResource("4")
 
-[node name="Terrain" type="TileMapLayer" parent="TileMap"]
+[node name="TileMap" type="TileMap" parent="HexMap"]
+tile_set = ExtResource("2")
+cell_tile_size = Vector2i(96, 84)
 
-[node name="Buildings" type="TileMapLayer" parent="TileMap"]
+[node name="Terrain" type="TileMapLayer" parent="HexMap/TileMap"]
+
+[node name="Buildings" type="TileMapLayer" parent="HexMap/TileMap"]
 z_index = 2
 
-[node name="Fog" type="TileMapLayer" parent="TileMap"]
+[node name="Fog" type="TileMapLayer" parent="HexMap/TileMap"]
 z_index = 1
 script = ExtResource("3")
 

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -2,7 +2,9 @@ extends Node2D
 
 signal tile_clicked(qr: Vector2i)
 
-@onready var hex_map: TileMap = $TileMap
+@onready var cam: Camera2D = $Camera2D
+@onready var grid: TileMap = $HexMap/TileMap
+@onready var hex_map: HexMap = $HexMap
 @onready var units_root: Node2D = $Units
 @onready var battle_manager: Node = $BattleManager
 
@@ -17,6 +19,7 @@ const RaiderManager = preload("res://scripts/world/RaiderManager.gd")
 var raider_manager: RaiderManager
 
 func _ready() -> void:
+    cam.position = grid.map_to_local(Vector2i(0, 0))
     raider_manager = RaiderManager.new()
     add_child(raider_manager)
     raider_manager.setup(hex_map, units_root, unit_scene)


### PR DESCRIPTION
## Summary
- refactor HexMap script to work with TileMapLayer nodes instead of layer indices
- center world camera on origin using TileMap
- restructure World scene to host new HexMap node with dedicated layers

## Testing
- `godot3 --headless --script tests/test_runner.gd` *(fails: incompatible engine version)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1ae82c2e083309f8183a43e23f24b