### PR TITLE
docs: add Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,21 @@ Vertical slice WIP: 3 buildings, 3 units, hex-grid combat, 1 neighbor AI, presti
 ## Build
 1. Open in Godot 4.x
 2. Press ▶ to run
-3. Exports via export_presets.cfg (to be added)
+3. Exports via `export_presets.cfg` (Linux, Web, Windows)
+
+## Running on Windows 11
+
+### Minimum Requirements
+- Windows 11 (64-bit) with a Vulkan-capable GPU
+- Godot Engine 4.4.x for Windows
+- 4 GB RAM and 1 GB free disk space
+
+### How to Run
+1. Download and install Godot 4.4.x for Windows.
+2. Clone this repository and open `project.godot` in Godot.
+   - Or run directly: `godot4.exe --path .`
+3. (Optional) Run tests: `godot4.exe --headless -s tests/test_runner.gd`
+4. To export a standalone build, use the included **Windows Desktop** export preset.
 
 ## Runbook
 Open the project in Godot 4.x (Standard). In Project Settings, confirm the Main Scene is `scenes/ui/Main.tscn` and AutoLoads include `GameClock` (`res://autoload/GameClock.gd`) and `GameState` (`res://autoload/GameState.gd`). Press ▶ to run, then use the Save/Load demo to test persistence.

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -43,3 +43,26 @@ texture_format/bptc=false
 texture_format/s3tc=false
 texture_format/etc2=true
 texture_format/etc=false
+
+[preset.2]
+name="Windows"
+platform="Windows Desktop"
+runnable=true
+custom_features=""
+dedicated_server=false
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+encryption_include_filters=""
+encryption_exclude_filters=""
+script_encryption_key=""
+export_path="export/windows/finsim_aa-club.exe"
+
+[preset.2.options]
+binary_format/64_bits=true
+binary_format/embed_pck=false
+texture_format/bptc=true
+texture_format/s3tc=true
+texture_format/etc2=false
+texture_format/etc=false
+binary_format/compress=false


### PR DESCRIPTION
## Summary
- document how to run the game on Windows 11, including minimum requirements and test commands
- add a Windows Desktop export preset

## Testing
- `./godot-bin/Godot_v4.4.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: Parse Error: Could not resolve class "HexMap")*


------
https://chatgpt.com/codex/tasks/task_e_68c1833b55948330bdb45fd1c6c6db4a