### PR TITLE
Ensure initial area is revealed

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -34,9 +34,13 @@ func _ready() -> void:
     _ensure_singletons()
     if _state.tiles.is_empty():
         _generate_tiles()
-        reveal_area(Vector2i.ZERO, 2)
     else:
         _draw_from_saved(_state.tiles)
+    reveal_area(Vector2i.ZERO, 2)
+    if fog != null:
+        for coord in _state.tiles.keys():
+            if HexUtils.axial_distance(coord, Vector2i.ZERO) <= 2:
+                fog.erase_cell(coord)
 
 func _setup_tileset() -> void:
     if grid.tile_set == null:


### PR DESCRIPTION
## Summary
- Always reveal starting hexes and clear fog after map setup

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bafb68e0833084e5312485ea7364