### PR TITLE
Separate extends declarations for test classes

### DIFF
--- a/tests/test_events.gd
+++ b/tests/test_events.gd
@@ -3,7 +3,9 @@ var Resources = preload("res://scripts/core/Resources.gd")
 var GameEvent = preload("res://scripts/events/Event.gd")
 var ColdSnapEvent = preload("res://scripts/events/ColdSnap.gd")
 
-class DummyEvent extends GameEvent:
+class DummyEvent:
+    extends GameEvent
+
     func apply() -> bool:
         return false
 

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -3,13 +3,18 @@ extends Node
 const HexMapBase = preload("res://scripts/world/HexMap.gd")
 const HexUtils = preload("res://scripts/world/HexUtils.gd")
 
-class DummyHexMap extends HexMapBase:
+class DummyHexMap:
+    extends HexMapBase
+
     func _init():
         tile_set = TileSet.new()
+
     func _set_tile(coord: Vector2i) -> void:
         pass
+
     func _setup_tileset() -> void:
         pass
+
     func reveal_area(center: Vector2i, radius: int = 2) -> void:
         for coord in GameState.tiles.keys():
             if HexUtils.axial_distance(coord, center) <= radius:


### PR DESCRIPTION
## Summary
- Split `extends` clauses onto their own lines for `DummyEvent` and `DummyHexMap` in test suite
- Ensure class bodies and methods are properly indented beneath new `extends` lines

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: project's `config_version` 5 requires Godot 4)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c8f7798c8330a58f2304f3962546