### PR TITLE
Use const for preloaded test scripts

### DIFF
--- a/tests/test_action.gd
+++ b/tests/test_action.gd
@@ -1,9 +1,9 @@
 extends Node
 
-var Action = preload("res://scripts/core/Action.gd")
-var Policy = preload("res://scripts/policies/Policy.gd")
-var GameEvent = preload("res://scripts/events/Event.gd")
-var Resources = preload("res://scripts/core/Resources.gd")
+const Action = preload("res://scripts/core/Action.gd")
+const Policy = preload("res://scripts/policies/Policy.gd")
+const GameEvent = preload("res://scripts/events/Event.gd")
+const Resources = preload("res://scripts/core/Resources.gd")
 
 func test_policy_apply_and_cooldown(res):
     var gs = Engine.get_main_loop().root.get_node("GameState")

--- a/tests/test_events.gd
+++ b/tests/test_events.gd
@@ -1,7 +1,7 @@
 extends Node
-var Resources = preload("res://scripts/core/Resources.gd")
-var GameEvent = preload("res://scripts/events/Event.gd")
-var ColdSnapEvent = preload("res://scripts/events/ColdSnap.gd")
+const Resources = preload("res://scripts/core/Resources.gd")
+const GameEvent = preload("res://scripts/events/Event.gd")
+const ColdSnapEvent = preload("res://scripts/events/ColdSnap.gd")
 
 class DummyEvent extends GameEvent:
     func apply() -> bool:

--- a/tests/test_resources.gd
+++ b/tests/test_resources.gd
@@ -1,5 +1,5 @@
 extends Node
-var Resources = preload("res://scripts/core/Resources.gd")
+const Resources = preload("res://scripts/core/Resources.gd")
 
 func test_game_state_resources(res) -> void:
     var gs = Engine.get_main_loop().root.get_node("GameState")

--- a/tests/test_saunakunnia.gd
+++ b/tests/test_saunakunnia.gd
@@ -1,5 +1,5 @@
 extends Node
-var Resources = preload("res://scripts/core/Resources.gd")
+const Resources = preload("res://scripts/core/Resources.gd")
 
 func test_saunakunnia_resets(res) -> void:
     var tree = Engine.get_main_loop()


### PR DESCRIPTION
## Summary
- Load test dependencies as `const` to enable type hints and compile-time constants

## Testing
- `godot3-server --headless --path . -s tests/test_runner.gd` *(fails: Can't open project due to config version 5; expected 4)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c8f3a4d0833091934ab938d0c335