### PR TITLE
refactor: rename preloads to avoid class conflicts

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -3,11 +3,12 @@ extends Node
 # The autoload provides the EventManager singleton; avoid registering a global
 # class name that conflicts with the autoload itself.
 
+const GameEventBase := preload("res://scripts/events/Event.gd")
+
 var events: Array = []
-var current_event: GameEvent = null
+var current_event: GameEventBase = null
 var _ticks_until_event: int = 0
 
-const GameEvent = preload("res://scripts/events/Event.gd")
 const OVERLAY_SCENE := preload("res://scenes/ui/EventOverlay.tscn")
 
 func _ready() -> void:
@@ -20,7 +21,7 @@ func _load_events() -> void:
     for file in DirAccess.get_files_at("res://resources/events"):
         if file.get_extension() == "tres":
             var res := load("res://resources/events/%s" % file)
-            if res is GameEvent:
+            if res is GameEventBase:
                 events.append(res)
 
 func _schedule_next_event() -> void:
@@ -33,11 +34,11 @@ func _on_tick() -> void:
     if _ticks_until_event <= 0:
         if events.size() > 0:
             var idx := int(RNG.randf() * events.size())
-            var ev: GameEvent = events[idx]
+            var ev: GameEventBase = events[idx]
             if ev.can_trigger():
                 start_event(ev)
 
-func start_event(ev: GameEvent) -> void:
+func start_event(ev: GameEventBase) -> void:
     if current_event:
         return
     if not ev.can_trigger():
@@ -70,7 +71,7 @@ func _on_choice_selected(choice: Dictionary) -> void:
     var next_path: String = choice.get("next_event", "")
     current_event = null
     if next_path != "":
-        var next_ev: GameEvent = load(next_path)
+        var next_ev: GameEventBase = load(next_path)
         start_event(next_ev)
     else:
         GameClock.start()

--- a/scripts/ui/EventOverlay.gd
+++ b/scripts/ui/EventOverlay.gd
@@ -3,13 +3,13 @@ class_name EventOverlay
 
 signal choice_selected(choice: Dictionary)
 
-const GameEvent = preload("res://scripts/events/Event.gd")
+const GameEventBase = preload("res://scripts/events/Event.gd")
 
 @onready var title_label: Label = $Panel/Title
 @onready var description_label: Label = $Panel/Description
 @onready var choices_container: VBoxContainer = $Panel/Choices
 
-func show_event(ev: GameEvent) -> void:
+func show_event(ev: GameEventBase) -> void:
     title_label.text = ev.name
     description_label.text = ev.description
     for c in ev.choices:

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -20,12 +20,12 @@ signal building_selected
 @onready var info_box: InfoBox = $InfoBox
 
 var _policies: Array[Policy] = []
-var _events: Array[GameEvent] = []
+var _events: Array[GameEventBase] = []
 var _buildings_info: Array[Building] = []
 
 const Building = preload("res://scripts/core/Building.gd")
 const Policy = preload("res://scripts/policies/Policy.gd")
-const GameEvent = preload("res://scripts/events/Event.gd")
+const GameEventBase = preload("res://scripts/events/Event.gd")
 
 func _ready() -> void:
     start_button.pressed.connect(func(): start_pressed.emit())
@@ -78,7 +78,7 @@ func _on_policy_pressed() -> void:
 func _on_event_pressed() -> void:
     var idx := event_selector.get_selected()
     if idx >= 0 and idx < _events.size():
-        var ev: GameEvent = _events[idx]
+        var ev: GameEventBase = _events[idx]
         if ev.can_trigger():
             EventManager.start_event(ev)
             event_label.text = "%s triggered" % ev.name
@@ -122,6 +122,6 @@ func _populate_events() -> void:
     event_selector.clear()
     for file in DirAccess.get_files_at("res://resources/events"):
         if file.get_extension() == "tres":
-            var e: GameEvent = load("res://resources/events/%s" % file)
+            var e: GameEventBase = load("res://resources/events/%s" % file)
             event_selector.add_item(e.name)
             _events.append(e)

--- a/scripts/units/Unit.gd
+++ b/scripts/units/Unit.gd
@@ -1,8 +1,8 @@
 extends Node2D
 
-const UnitData = preload("res://scripts/units/UnitData.gd")
+const UnitDataBase = preload("res://scripts/units/UnitData.gd")
 
-@export var unit_data: UnitData
+@export var unit_data: UnitDataBase
 var id: String = str(Time.get_unix_time_from_system())
 var type := "kiuasvartija"
 var hp := 100
@@ -15,7 +15,7 @@ func _ready() -> void:
     if unit_data:
         apply_data(unit_data)
 
-func apply_data(d: UnitData) -> void:
+func apply_data(d: UnitDataBase) -> void:
     unit_data = d
     if unit_data:
         type = unit_data.name
@@ -38,7 +38,7 @@ func from_dict(data: Dictionary) -> void:
     pos_qr = data.get("pos_qr", pos_qr)
     var path: String = data.get("data_path", "")
     if path != "":
-        var ud: UnitData = load(path) as UnitData
+        var ud: UnitDataBase = load(path) as UnitDataBase
         if ud:
             apply_data(ud)
     hp = data.get("hp", hp)

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -15,6 +15,7 @@ const AutoResolve = preload("res://scripts/battle/AutoResolve.gd")
 const Resources = preload("res://scripts/core/Resources.gd")
 
 const RaiderManager = preload("res://scripts/world/RaiderManager.gd")
+const UnitDataBase = preload("res://scripts/units/UnitData.gd")
 
 var raider_manager: RaiderManager
 
@@ -59,7 +60,7 @@ func _on_game_tick() -> void:
 
 func spawn_unit_at_center() -> void:
     var u: Node = unit_scene.instantiate()
-    var data_res: UnitData = load("res://resources/units/saunoja.tres")
+    var data_res: UnitDataBase = load("res://resources/units/saunoja.tres")
     if data_res:
         u.apply_data(data_res)
     u.id = UUID.new_uuid_string()

--- a/tests/test_action.gd
+++ b/tests/test_action.gd
@@ -2,8 +2,8 @@ extends Node
 
 const Action = preload("res://scripts/core/Action.gd")
 const Policy = preload("res://scripts/policies/Policy.gd")
-const GameEvent = preload("res://scripts/events/Event.gd")
 const Resources = preload("res://scripts/core/Resources.gd")
+const GameEventBase = preload("res://scripts/events/Event.gd")
 
 func test_policy_apply_and_cooldown(res):
     var gs = Engine.get_main_loop().root.get_node("GameState")
@@ -31,7 +31,7 @@ func test_event_inherits_action(res):
     gs.res[Resources.KULTA] = 100.0
     gs.res[Resources.SAUNATUNNELMA] = 0.0
     gs.res[Resources.MAKKARA] = 0.0
-    var ev: GameEvent = load("res://resources/events/rain.tres")
+    var ev: GameEventBase = load("res://resources/events/rain.tres")
     if not (ev is Action):
         res.fail("Event does not inherit Action")
         return
@@ -53,7 +53,7 @@ func test_sauna_diplomacy(res):
     gs.res[Resources.HALOT] = 50.0
     gs.res[Resources.LOYLY] = 1.0
     gs.res[Resources.LAUDEVALTA] = 0.0
-    var ev: GameEvent = load("res://resources/events/sauna_diplomacy.tres")
+    var ev: GameEventBase = load("res://resources/events/sauna_diplomacy.tres")
     if not ev.can_trigger():
         res.fail("Sauna Diplomacy cannot trigger")
         gs.res = orig_res

--- a/tests/test_events.gd
+++ b/tests/test_events.gd
@@ -1,10 +1,10 @@
 extends Node
 const Resources = preload("res://scripts/core/Resources.gd")
-const GameEvent = preload("res://scripts/events/Event.gd")
 const ColdSnapEvent = preload("res://scripts/events/ColdSnap.gd")
+const GameEventBase = preload("res://scripts/events/Event.gd")
 
 class DummyEvent:
-    extends GameEvent
+    extends GameEventBase
 
     func apply() -> bool:
         return false
@@ -22,11 +22,11 @@ func test_branching_event(res) -> void:
     clock.set_process(false)
     gs.res[Resources.HALOT] = 20.0
     gs.res[Resources.MAKKARA] = 0.0
-    var ev: GameEvent = load("res://resources/events/merchant.tres")
+    var ev: GameEventBase = load("res://resources/events/merchant.tres")
     em.start_event(ev)
     em._on_choice_selected(ev.choices[0])
     _cleanup_overlays(tree)
-    var follow_up: GameEvent = em.current_event
+    var follow_up: GameEventBase = em.current_event
     if follow_up == null or follow_up.name != "Merchant Returns":
         res.fail("follow-up event not started")
         return
@@ -78,7 +78,7 @@ func test_event_fails_prerequisites(res) -> void:
     var em = tree.root.get_node("EventManager")
     var orig = gs.res.duplicate()
     gs.res[Resources.HALOT] = 0.0
-    var ev: GameEvent = load("res://resources/events/merchant.tres")
+    var ev: GameEventBase = load("res://resources/events/merchant.tres")
     if ev.can_trigger():
         res.fail("event unexpectedly triggerable")
         gs.res = orig
@@ -101,7 +101,7 @@ func test_unaffordable_choice_keeps_resources(res) -> void:
     clock.set_process(false)
     var orig = gs.res.duplicate()
     gs.res[Resources.HALOT] = 0.0
-    var ev: GameEvent = load("res://resources/events/merchant.tres")
+    var ev: GameEventBase = load("res://resources/events/merchant.tres")
     em.start_event(ev)
     var before := gs.res.duplicate()
     em._on_choice_selected(ev.choices[0])


### PR DESCRIPTION
## Summary
- avoid global class name collisions by renaming preloaded GameEvent and UnitData scripts
- update event, UI, and unit code to use new aliases
- adjust tests and world logic to reference renamed classes

## Testing
- `/tmp/godot-bin/Godot_v4.3-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: Parse Error: Could not resolve class "HexMap" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cabd2b3c83309d810ec58f6bdb4d