### PR TITLE
Use HexMap type for tilemap references

### DIFF
--- a/scripts/battle/BattleManager.gd
+++ b/scripts/battle/BattleManager.gd
@@ -4,13 +4,13 @@ class_name BattleManager
 const HexNavigator = preload("res://scripts/battle/HexNavigator.gd")
 
 var world: Node = null
-var hex_map: TileMap = null
+var hex_map: HexMap = null
 var units_root: Node2D = null
 
 func _ready() -> void:
     world = get_parent()
     if world:
-        hex_map = world.get_node("TileMap")
+        hex_map = world.get_node("HexMap") as HexMap
         units_root = world.get_node("Units")
 
 func process_tick() -> void:

--- a/scripts/world/RaiderManager.gd
+++ b/scripts/world/RaiderManager.gd
@@ -3,14 +3,14 @@ extends Node
 const Pathing = preload("res://scripts/world/Pathing.gd")
 const HexUtils = preload("res://scripts/world/HexUtils.gd")
 
-var hex_map: TileMap
+var hex_map: HexMap
 var units_root: Node2D
 var unit_scene: PackedScene
 
 var raiders: Array = []
 var _tick_counter: int = 0
 
-func setup(hmap: TileMap, units: Node2D, scene: PackedScene) -> void:
+func setup(hmap: HexMap, units: Node2D, scene: PackedScene) -> void:
     hex_map = hmap
     units_root = units
     unit_scene = scene


### PR DESCRIPTION
## Summary
- Replace TileMap with HexMap in battle manager
- Update raider manager to accept HexMap

## Testing
- `godot3-server --path . --headless -s tests/test_hexmap.gd` *(fails: project uses newer config version)*

------
https://chatgpt.com/codex/tasks/task_e_68c24d553718833083abdf45e5203f21