### PR TITLE
Fix AutoResolve ternary and add UUID helper

### DIFF
--- a/scripts/battle/AutoResolve.gd
+++ b/scripts/battle/AutoResolve.gd
@@ -50,7 +50,7 @@ static func resolve(friendly: Array, enemies: Array, terrain: String) -> Diction
         var ehp := 0
         for e in enemies:
             ehp += e.get("hp", 0)
-        winner = fhp >= ehp ? "friendly" : "enemy"
+        winner = "friendly" if fhp >= ehp else "enemy"
     return {
         "friendly": friendly,
         "enemies": enemies,

--- a/scripts/core/UUID.gd
+++ b/scripts/core/UUID.gd
@@ -1,0 +1,14 @@
+extends RefCounted
+class_name UUID
+
+static func new_uuid_string() -> String:
+    var chars := "0123456789abcdef"
+    var sections := [8, 4, 4, 4, 12]
+    var parts: Array[String] = []
+    for length in sections:
+        var part := ""
+        for i in range(length):
+            part += chars[RNG.randi() % chars.length()]
+        parts.append(part)
+    return parts.join("-")
+


### PR DESCRIPTION
## Summary
- implement missing `UUID` helper for unique IDs
- fix AutoResolve ternary syntax for Godot 4

## Testing
- `/tmp/Godot_v4.1.1-stable_linux.x86_64 --headless --path . --script res://tests/test_runner.gd` *(fails: Could not resolve class "HexMap"...)*

------
https://chatgpt.com/codex/tasks/task_e_68c24f3fab888330b5b80f56373e354e