### PR TITLE
Update fog to use TileMapLayer

### DIFF
--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -4,7 +4,7 @@ class_name FogMap
 var source_id := -1
 
 func _ready() -> void:
-    var tile_map := get_parent() as TileMap
+    var tile_map := get_parent() as TileMapLayer
     var tset := tile_map.tile_set
     if tset == null:
         tset = TileSet.new()


### PR DESCRIPTION
## Summary
- Cast fog parent as TileMapLayer to match updated API

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `/tmp/godot/Godot_v4.4.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: Parse Error: Could not resolve class "HexMap" and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c24eec2aa083308a8edd67de1b4d8b