### PR TITLE
Fix InfoBox cost label conditional expression

### DIFF
--- a/scripts/ui/InfoBox.gd
+++ b/scripts/ui/InfoBox.gd
@@ -23,5 +23,5 @@ func show_building(building: Building) -> void:
     var cost: Dictionary = building.get_construction_cost()
     for key in cost.keys():
         cost_parts.append("%s: %s" % [key.capitalize(), str(cost[key])])
-    cost_label.text = cost_parts.size() > 0 ? "Cost: " + ", ".join(cost_parts) : ""
+    cost_label.text = ("Cost: " + ", ".join(cost_parts)) if cost_parts.size() > 0 else ""
     show()


### PR DESCRIPTION
## Summary
- use GDScript-style conditional expression for InfoBox cost label to avoid parse errors

## Testing
- `godot --headless --path . --script tests/test_runner.gd` *(fails: Parse Error: Could not resolve class "HexMap")*

------
https://chatgpt.com/codex/tasks/task_e_68c2547007b08330b128cbae13cd9482