### PR TITLE
Resolve GDScript naming conflicts

### DIFF
--- a/scripts/battle/BattleManager.gd
+++ b/scripts/battle/BattleManager.gd
@@ -1,7 +1,6 @@
 extends Node
 class_name BattleManager
 
-const HexNavigator = preload("res://scripts/battle/HexNavigator.gd")
 
 var world: Node = null
 var hex_map: HexMap = null

--- a/scripts/battle/HexNavigator.gd
+++ b/scripts/battle/HexNavigator.gd
@@ -1,7 +1,6 @@
 extends Object
 class_name HexNavigator
 
-const HexUtils = preload("res://scripts/world/HexUtils.gd")
 
 static func nearest_hostile_path(start: Vector2i, tiles: Dictionary) -> Array[Vector2i]:
     if tiles.is_empty():

--- a/scripts/events/ColdSnap.gd
+++ b/scripts/events/ColdSnap.gd
@@ -1,7 +1,6 @@
 extends GameEvent
 class_name ColdSnapEvent
 
-const Resources = preload("res://scripts/core/Resources.gd")
 
 @export var duration_ticks: int = 30
 @export var penalty_multiplier: float = 0.8

--- a/scripts/events/RuneDiscovery.gd
+++ b/scripts/events/RuneDiscovery.gd
@@ -1,7 +1,6 @@
 extends GameEvent
 class_name RuneDiscoveryEvent
 
-const Resources = preload("res://scripts/core/Resources.gd")
 
 @export var required_saunatieto: float = 5.0
 

--- a/scripts/events/Trader.gd
+++ b/scripts/events/Trader.gd
@@ -1,7 +1,6 @@
 extends GameEvent
 class_name TraderEvent
 
-const Resources = preload("res://scripts/core/Resources.gd")
 
 @export var required_halot: float = 10.0
 

--- a/scripts/systems/SisuSystem.gd
+++ b/scripts/systems/SisuSystem.gd
@@ -1,6 +1,5 @@
 extends Node
 
-const Resources = preload("res://scripts/core/Resources.gd")
 
 const COOLDOWN_TICKS := 20 # 10 seconds at 0.5s per tick
 

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -23,8 +23,6 @@ var _policies: Array[Policy] = []
 var _events: Array[GameEventBase] = []
 var _buildings_info: Array[Building] = []
 
-const Building = preload("res://scripts/core/Building.gd")
-const Policy = preload("res://scripts/policies/Policy.gd")
 const GameEventBase = preload("res://scripts/events/Event.gd")
 
 func _ready() -> void:

--- a/scripts/ui/InfoBox.gd
+++ b/scripts/ui/InfoBox.gd
@@ -1,7 +1,6 @@
 extends Panel
 class_name InfoBox
 
-const Building = preload("res://scripts/core/Building.gd")
 
 @onready var name_label: Label = $VBoxContainer/NameLabel
 @onready var description_label: Label = $VBoxContainer/DescriptionLabel

--- a/scripts/ui/Main.gd
+++ b/scripts/ui/Main.gd
@@ -1,7 +1,6 @@
 extends Node
 
-const Building = preload("res://scripts/core/Building.gd")
-const TutorialOverlay = preload("res://scenes/ui/TutorialOverlay.tscn")
+const TutorialOverlayScene = preload("res://scenes/ui/TutorialOverlay.tscn")
 
 @onready var world: Node = $World
 @onready var hud: CanvasLayer = $Hud
@@ -40,8 +39,8 @@ func _on_game_tick() -> void:
     hud.update_resources(GameState.res)
     _update_sisu_button()
 
-func _on_building_selected(name: String) -> void:
-    _selected_building = _buildings.get(name, null)
+func _on_building_selected(building_name: String) -> void:
+    _selected_building = _buildings.get(building_name, null)
 
 func _on_build_pressed() -> void:
     if _selected_building == null:
@@ -88,7 +87,7 @@ func _update_sisu_button() -> void:
 func start_tutorial() -> void:
     if _tutorial_overlay:
         _tutorial_overlay.queue_free()
-    _tutorial_overlay = TutorialOverlay.instantiate()
+    _tutorial_overlay = TutorialOverlayScene.instantiate()
     add_child(_tutorial_overlay)
     _tutorial_overlay.tutorial_completed.connect(_on_tutorial_completed)
 

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -6,7 +6,6 @@ class_name HexMap
 
 signal tile_clicked(qr:Vector2i)
 
-const HexUtils = preload("res://scripts/world/HexUtils.gd")
 
 @onready var grid: TileMap = $TileMap
 @onready var terrain: TileMapLayer = $TileMap/Terrain
@@ -53,14 +52,14 @@ func _setup_tileset() -> void:
             "hill": Color(0.5,0.5,0.5),
             "lake": Color(0,0.3,0.8),
         }
-        for name in ["forest","taiga","hill","lake"]:
+        for terrain_name in ["forest","taiga","hill","lake"]:
             var img := Image.create(size.x, size.y, false, Image.FORMAT_RGBA8)
-            img.fill(colors[name])
+            img.fill(colors[terrain_name])
             var tex := ImageTexture.create_from_image(img)
             var src := TileSetAtlasSource.new()
             src.texture = tex
             var sid := grid.tile_set.add_source(src)
-            _terrain_sources[name] = sid
+            _terrain_sources[terrain_name] = sid
     else:
         var names := ["forest","taiga","hill","lake"]
         var ids: Array[int] = grid.tile_set.get_source_id_list()
@@ -77,22 +76,22 @@ func _setup_building_tiles() -> void:
         "mine": Color(0.5, 0.5, 0.5),
         "school": Color(0.3, 0.5, 0.9),
     }
-    for name in colors.keys():
+    for bname in colors.keys():
         var img := Image.create(48, 48, false, Image.FORMAT_RGBA8)
-        img.fill(colors[name])
+        img.fill(colors[bname])
         var inner := Image.create(24, 24, false, Image.FORMAT_RGBA8)
         inner.fill(Color.WHITE)
         img.blit_rect(inner, Rect2i(Vector2i.ZERO, inner.get_size()), Vector2i(12, 12))
         var big := Image.create(size.x, size.y, false, Image.FORMAT_RGBA8)
         big.fill(Color(0, 0, 0, 0))
-        var off := Vector2i((size.x - img.get_width()) / 2, (size.y - img.get_height()) / 2)
+        var off := Vector2i((size.x - img.get_width()) // 2, (size.y - img.get_height()) // 2)
         big.blit_rect(img, Rect2i(Vector2i.ZERO, img.get_size()), off)
         var tex := ImageTexture.create_from_image(big)
         var src := TileSetAtlasSource.new()
         src.texture = tex
         src.texture_region_size = size
         var sid := grid.tile_set.add_source(src)
-        _building_sources[name] = sid
+        _building_sources[bname] = sid
 
 func _generate_tiles() -> void:
     _ensure_singletons()
@@ -169,10 +168,10 @@ func _unhandled_input(event: InputEvent) -> void:
             print("Hex %d,%d terrain %s" % [cell.x, cell.y, terrain_name])
             emit_signal("tile_clicked", cell)
 
-func reveal_area(center: Vector2i, radius: int = 2) -> void:
+func reveal_area(center: Vector2i, reveal_radius: int = 2) -> void:
     _ensure_singletons()
     for coord in _state.tiles.keys():
-        if HexUtils.axial_distance(coord, center) <= radius:
+        if HexUtils.axial_distance(coord, center) <= reveal_radius:
             _state.tiles[coord]["explored"] = true
             if fog != null:
                 fog.erase_cell(coord)
@@ -185,12 +184,12 @@ func reveal_all() -> void:
             fog.erase_cell(coord)
 
 func axial_to_world(qr: Vector2i) -> Vector2:
-    var radius := grid.tile_set.tile_size.x / 2.0
-    return HexUtils.axial_to_world(qr.x, qr.y, radius)
+    var hex_radius := grid.tile_set.tile_size.x / 2.0
+    return HexUtils.axial_to_world(qr.x, qr.y, hex_radius)
 
 func world_to_axial(pos: Vector2) -> Vector2i:
-    var radius := grid.tile_set.tile_size.x / 2.0
-    return HexUtils.world_to_axial(pos, radius)
+    var hex_radius := grid.tile_set.tile_size.x / 2.0
+    return HexUtils.world_to_axial(pos, hex_radius)
 
 func map_to_pos(cell: Vector2i) -> Vector2:
     return grid.map_to_local(cell)

--- a/scripts/world/HexUtils.gd
+++ b/scripts/world/HexUtils.gd
@@ -10,7 +10,6 @@ const HEX_DIRS = [
     Vector2i(0,1),
 ]
 
-const RNG = preload("res://autoload/RNG.gd")
 
 static func axial_to_world(q: int, r: int, hex_radius: float) -> Vector2:
     var x := hex_radius * sqrt(3.0) * (q + r / 2.0)

--- a/scripts/world/MapGenerator.gd
+++ b/scripts/world/MapGenerator.gd
@@ -5,8 +5,6 @@ extends Node2D
 @export var seed: int = 0
 @export var hex_radius: float = 32.0
 
-const HexUtils = preload("res://scripts/world/HexUtils.gd")
-const Resources = preload("res://scripts/core/Resources.gd")
 var noise := FastNoiseLite.new()
 @onready var hex_tile_scene: PackedScene = preload("res://scenes/world/HexTile.tscn")
 var _state: Node

--- a/scripts/world/Pathing.gd
+++ b/scripts/world/Pathing.gd
@@ -1,6 +1,5 @@
 extends Object
 class_name Pathing
-const HexUtils = preload("res://scripts/world/HexUtils.gd")
 
 static func bfs_path(start: Vector2i, goal: Vector2i, passable: Callable) -> Array[Vector2i]:
     if start == goal:

--- a/scripts/world/RaiderManager.gd
+++ b/scripts/world/RaiderManager.gd
@@ -1,7 +1,5 @@
 extends Node
 
-const Pathing = preload("res://scripts/world/Pathing.gd")
-const HexUtils = preload("res://scripts/world/HexUtils.gd")
 
 var hex_map: HexMap
 var units_root: Node2D

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -10,9 +10,6 @@ signal tile_clicked(qr: Vector2i)
 
 var selected_unit: Node = null
 var unit_scene: PackedScene = preload("res://scenes/units/Unit.tscn")
-const Pathing = preload("res://scripts/world/Pathing.gd")
-const AutoResolve = preload("res://scripts/battle/AutoResolve.gd")
-const Resources = preload("res://scripts/core/Resources.gd")
 
 const RaiderManager = preload("res://scripts/world/RaiderManager.gd")
 const UnitDataBase = preload("res://scripts/units/UnitData.gd")

--- a/tests/test_action.gd
+++ b/tests/test_action.gd
@@ -1,8 +1,5 @@
 extends Node
 
-const Action = preload("res://scripts/core/Action.gd")
-const Policy = preload("res://scripts/policies/Policy.gd")
-const Resources = preload("res://scripts/core/Resources.gd")
 const GameEventBase = preload("res://scripts/events/Event.gd")
 
 func test_policy_apply_and_cooldown(res):

--- a/tests/test_events.gd
+++ b/tests/test_events.gd
@@ -1,6 +1,4 @@
 extends Node
-const Resources = preload("res://scripts/core/Resources.gd")
-const ColdSnapEvent = preload("res://scripts/events/ColdSnap.gd")
 const GameEventBase = preload("res://scripts/events/Event.gd")
 
 class DummyEvent:

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -1,7 +1,6 @@
 extends Node
 
 const HexMapBase = preload("res://scripts/world/HexMap.gd")
-const HexUtils = preload("res://scripts/world/HexUtils.gd")
 
 class DummyHexMap:
     extends HexMapBase
@@ -15,9 +14,9 @@ class DummyHexMap:
     func _setup_tileset() -> void:
         pass
 
-    func reveal_area(center: Vector2i, radius: int = 2) -> void:
+    func reveal_area(center: Vector2i, reveal_radius: int = 2) -> void:
         for coord in GameState.tiles.keys():
-            if HexUtils.axial_distance(coord, center) <= radius:
+            if HexUtils.axial_distance(coord, center) <= reveal_radius:
                 GameState.tiles[coord]["explored"] = true
 
 func _reset_tiles() -> void:

--- a/tests/test_resources.gd
+++ b/tests/test_resources.gd
@@ -1,5 +1,4 @@
 extends Node
-const Resources = preload("res://scripts/core/Resources.gd")
 
 func test_game_state_resources(res) -> void:
     var gs = Engine.get_main_loop().root.get_node("GameState")

--- a/tests/test_rng.gd
+++ b/tests/test_rng.gd
@@ -1,9 +1,9 @@
 extends Node
-var RNG = preload("res://autoload/RNG.gd")
+var RNGClass = preload("res://autoload/RNG.gd")
 
 func test_seed_generates_same_sequence(res):
-    var rng1 = RNG.new()
-    var rng2 = RNG.new()
+    var rng1 = RNGClass.new()
+    var rng2 = RNGClass.new()
     rng1.seed_from_string("seed")
     rng2.seed_from_string("seed")
     if rng1.randi() != rng2.randi():
@@ -12,7 +12,7 @@ func test_seed_generates_same_sequence(res):
         res.fail("First randf should match for same seed")
 
 func test_randf_between_0_and_1(res):
-    var rng = RNG.new()
+    var rng = RNGClass.new()
     rng.seed_from_string("demo")
     var value = rng.randf()
     if value < 0.0 or value >= 1.0:

--- a/tests/test_saunakunnia.gd
+++ b/tests/test_saunakunnia.gd
@@ -1,5 +1,4 @@
 extends Node
-const Resources = preload("res://scripts/core/Resources.gd")
 
 func test_saunakunnia_resets(res) -> void:
     var tree = Engine.get_main_loop()


### PR DESCRIPTION
## Summary
- Remove redundant preloads that clashed with globally registered classes
- Clarify HexMap helpers: avoid shadowed variables and use explicit integer division
- Rename tutorial overlay scene preload and handler parameter to prevent name shadowing

## Testing
- ❌ `godot4 --headless -s tests/test_runner.gd` (command not found: godot4)


------
https://chatgpt.com/codex/tasks/task_e_68c255405d008330ac5708501e01c2ea