### PR TITLE
refactor: avoid floor division parse error

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -84,7 +84,12 @@ func _setup_building_tiles() -> void:
         img.blit_rect(inner, Rect2i(Vector2i.ZERO, inner.get_size()), Vector2i(12, 12))
         var big := Image.create(size.x, size.y, false, Image.FORMAT_RGBA8)
         big.fill(Color(0, 0, 0, 0))
-        var off := Vector2i((size.x - img.get_width()) // 2, (size.y - img.get_height()) // 2)
+        # Godot 4 uses "//" for integer division, but some tooling may not
+        # recognize it, causing parse errors. Use explicit casts to ensure
+        # compatibility with environments that only support "/".
+        var off_x := int((size.x - img.get_width()) / 2)
+        var off_y := int((size.y - img.get_height()) / 2)
+        var off := Vector2i(off_x, off_y)
         big.blit_rect(img, Rect2i(Vector2i.ZERO, img.get_size()), off)
         var tex := ImageTexture.create_from_image(big)
         var src := TileSetAtlasSource.new()


### PR DESCRIPTION
## Summary
- use explicit int division to compute offsets for building sprites

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68c2585c05148330a9f018236e947f61