### PR TITLE
Reuse fog TileSet source and match tile size

### DIFF
--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -1,6 +1,9 @@
 extends TileMapLayer
 class_name FogMap
 
+## Name used to identify the fog source within the TileSet.
+const FOG_SOURCE_NAME := "fog"
+
 var source_id: int = -1
 
 func _ready() -> void:
@@ -10,11 +13,23 @@ func _ready() -> void:
         tset = TileSet.new()
         tset.tile_shape = TileSet.TILE_SHAPE_HEXAGON
         tile_map.tile_set = tset
-    var size: Vector2i = tile_map.cell_tile_size
+    source_id = _get_or_create_fog_source(tset)
+
+## Generates a fog texture based on the TileSet tile size.
+func _generate_fog_texture(size: Vector2i) -> Texture2D:
     var img := Image.create(size.x, size.y, false, Image.FORMAT_RGBA8)
-    img.fill(Color(0,0,0,0.75))
-    var tex := ImageTexture.create_from_image(img)
+    img.fill(Color(0, 0, 0, 0.75))
+    return ImageTexture.create_from_image(img)
+
+## Returns an existing fog source or creates one if absent.
+func _get_or_create_fog_source(tset: TileSet) -> int:
+    var size: Vector2i = tset.tile_size
+    for id in tset.get_source_id_list():
+        var existing := tset.get_source(id)
+        if existing is TileSetAtlasSource and existing.resource_name == FOG_SOURCE_NAME:
+            return id
     var src := TileSetAtlasSource.new()
-    src.texture = tex
+    src.resource_name = FOG_SOURCE_NAME
+    src.texture = _generate_fog_texture(size)
     src.texture_region_size = size
-    source_id = tset.add_source(src)
+    return tset.add_source(src)


### PR DESCRIPTION
## Summary
- Reuse existing fog TileSet source if found instead of creating duplicate sources
- Generate fog texture only when missing and document expected source name
- Use TileSet.tile_size to size fog tiles to match primary tileset

## Testing
- `godot/Godot_v4.2.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: Could not preload resource script "res://scripts/world/HexMap.gd")*

------
https://chatgpt.com/codex/tasks/task_e_68c25895c85c833095767e837343d581