### PR TITLE
refactor: consolidate world layers into TileMap

### DIFF
--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -1,33 +1,23 @@
-[gd_scene load_steps=6]
+[gd_scene load_steps=5]
 
 [ext_resource path="res://scripts/world/World.gd" type="Script" id="1"]
 [ext_resource path="res://resources/TileSet.tres" type="TileSet" id="2"]
-[ext_resource path="res://scripts/world/FogMap.gd" type="Script" id="3"]
-[ext_resource path="res://scripts/world/HexMap.gd" type="Script" id="4"]
-[ext_resource path="res://scenes/battle/BattleManager.tscn" type="PackedScene" id="5"]
+[ext_resource path="res://scripts/world/HexMap.gd" type="Script" id="3"]
+[ext_resource path="res://scenes/battle/BattleManager.tscn" type="PackedScene" id="4"]
 
 [node name="World" type="Node2D"]
 script = ExtResource("1")
 
 [node name="HexMap" type="Node2D" parent="."]
-script = ExtResource("4")
+script = ExtResource("3")
 
 [node name="TileMap" type="TileMap" parent="HexMap"]
 tile_set = ExtResource("2")
 cell_tile_size = Vector2i(96, 84)
 
-[node name="Terrain" type="TileMapLayer" parent="HexMap/TileMap"]
-
-[node name="Buildings" type="TileMapLayer" parent="HexMap/TileMap"]
-z_index = 2
-
-[node name="Fog" type="TileMapLayer" parent="HexMap/TileMap"]
-z_index = 1
-script = ExtResource("3")
-
 [node name="Units" type="Node2D" parent="."]
 
-[node name="BattleManager" parent="." instance=ExtResource("5")]
+[node name="BattleManager" parent="." instance=ExtResource("4")]
 
 [node name="Camera2D" type="Camera2D" parent="."]
 current = true

--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -1,10 +1,13 @@
-extends TileMapLayer
+extends RefCounted
 class_name FogMap
 
+var tile_map: TileMap
+var layer: int = -1
 var source_id: int = -1
 
-func _ready() -> void:
-    var tile_map: TileMap = get_parent() as TileMap
+func setup(p_tile_map: TileMap, p_layer: int) -> void:
+    tile_map = p_tile_map
+    layer = p_layer
     var tset: TileSet = tile_map.tile_set
     if tset == null:
         tset = TileSet.new()
@@ -18,3 +21,9 @@ func _ready() -> void:
     src.texture = tex
     src.texture_region_size = size
     source_id = tset.add_source(src)
+
+func set_cell(coord: Vector2i, sid: int = source_id) -> void:
+    tile_map.set_cell(layer, coord, sid)
+
+func erase_cell(coord: Vector2i) -> void:
+    tile_map.erase_cell(layer, coord)


### PR DESCRIPTION
## Summary
- manage terrain, building, and fog layers via TileMap internal layers
- update HexMap and FogMap scripts to work with layer indices
- remove obsolete TileMapLayer nodes from world scene

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: project.godot config_version 5 requires newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c2589796cc83309a97a5263922fe23