### PR TITLE
refactor: use internal TileMap layers for fog and terrain

### DIFF
--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -4,15 +4,25 @@ class_name FogMap
 ## Name used to identify the fog source within the TileSet.
 const FOG_SOURCE_NAME := "fog"
 
+var tile_map: TileMap
+var layer: int
 var source_id: int = -1
 
-func _init(tile_map: TileMap) -> void:
+func _init(tile_map: TileMap, fog_layer: int) -> void:
+    self.tile_map = tile_map
+    self.layer = fog_layer
     var tset: TileSet = tile_map.tile_set
     if tset == null:
         tset = TileSet.new()
         tset.tile_shape = TileSet.TILE_SHAPE_HEXAGON
         tile_map.tile_set = tset
     source_id = _get_or_create_fog_source(tset)
+
+func set_fog(coord: Vector2i) -> void:
+    tile_map.set_cell(layer, coord, source_id)
+
+func clear_fog(coord: Vector2i) -> void:
+    tile_map.erase_cell(layer, coord)
 
 ## Generates a fog texture based on the TileSet tile size.
 func _generate_fog_texture(size: Vector2i) -> Texture2D:

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -45,7 +45,7 @@ func _ready() -> void:
     if fog != null:
         for coord in _state.tiles.keys():
             if HexUtils.axial_distance(coord, Vector2i.ZERO) <= 2:
-                grid.erase_cell(fog_layer, coord)
+                fog.clear_fog(coord)
 
 func _setup_layers() -> void:
     terrain_layer = grid.get_layer_by_name("Terrain")
@@ -63,7 +63,7 @@ func _setup_layers() -> void:
         fog_layer = grid.add_layer()
         grid.set_layer_name(fog_layer, "Fog")
     grid.set_layer_z_index(fog_layer, 1)
-    fog = FogMap.new(grid)
+    fog = FogMap.new(grid, fog_layer)
 
 func _setup_tileset() -> void:
     if grid.tile_set == null:
@@ -176,9 +176,9 @@ func _set_tile(coord: Vector2i) -> void:
         _markers.erase(coord)
     if fog != null:
         if data.get("explored", false):
-            grid.erase_cell(fog_layer, coord)
+            fog.clear_fog(coord)
         else:
-            grid.set_cell(fog_layer, coord, fog.source_id)
+            fog.set_fog(coord)
 
 func _random_terrain() -> String:
     _ensure_singletons()
@@ -206,14 +206,14 @@ func reveal_area(center: Vector2i, reveal_radius: int = 2) -> void:
         if HexUtils.axial_distance(coord, center) <= reveal_radius:
             _state.tiles[coord]["explored"] = true
             if fog != null:
-                grid.erase_cell(fog_layer, coord)
+                fog.clear_fog(coord)
 
 func reveal_all() -> void:
     _ensure_singletons()
     for coord in _state.tiles.keys():
         _state.tiles[coord]["explored"] = true
         if fog != null:
-            grid.erase_cell(fog_layer, coord)
+            fog.clear_fog(coord)
 
 func axial_to_world(qr: Vector2i) -> Vector2:
     var hex_radius := grid.tile_set.tile_size.x / 2.0


### PR DESCRIPTION
## Summary
- manage fog through helper using TileMap layer IDs
- switch HexMap to set and clear fog via helper

## Testing
- `apt-get install -y godot3-server`
- `godot3-server --path . -s tests/test_runner.gd` *(fails: Can't open project... config_version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68c25c55c3a08330be9b804e20159171