### PR TITLE
Fix TileMap layer setup for Godot 4

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -50,17 +50,20 @@ func _ready() -> void:
 func _setup_layers() -> void:
     terrain_layer = grid.get_layer_by_name("Terrain")
     if terrain_layer == -1:
-        terrain_layer = grid.add_layer()
+        grid.add_layer(-1)
+        terrain_layer = grid.get_layers_count() - 1
         grid.set_layer_name(terrain_layer, "Terrain")
     grid.set_layer_z_index(terrain_layer, 0)
     buildings_layer = grid.get_layer_by_name("Buildings")
     if buildings_layer == -1:
-        buildings_layer = grid.add_layer()
+        grid.add_layer(-1)
+        buildings_layer = grid.get_layers_count() - 1
         grid.set_layer_name(buildings_layer, "Buildings")
     grid.set_layer_z_index(buildings_layer, 2)
     fog_layer = grid.get_layer_by_name("Fog")
     if fog_layer == -1:
-        fog_layer = grid.add_layer()
+        grid.add_layer(-1)
+        fog_layer = grid.get_layers_count() - 1
         grid.set_layer_name(fog_layer, "Fog")
     grid.set_layer_z_index(fog_layer, 1)
     fog = FogMap.new(grid)


### PR DESCRIPTION
## Summary
- fix HexMap layer creation to call TileMap.add_layer with a position and fetch the index afterward

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project; config_version 5 incompatible)*

------
https://chatgpt.com/codex/tasks/task_e_68c25ccfe7648330b24f8b8c8b1d63f4