### PR TITLE
Migrate to TileMapLayer (Godot 4.4.1) & fix world rendering

### DIFF
--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -15,6 +15,12 @@ script = ExtResource("4")
 tile_set = ExtResource("2")
 cell_tile_size = Vector2i(96, 84)
 
+[node name="Terrain" type="TileMapLayer" parent="HexMap/TileMap"]
+
+[node name="Buildings" type="TileMapLayer" parent="HexMap/TileMap"]
+
+[node name="Fog" type="TileMapLayer" parent="HexMap/TileMap"]
+
 [node name="Units" type="Node2D" parent="."]
 
 [node name="BattleManager" parent="." instance=ExtResource("5")]

--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -5,10 +5,10 @@ class_name FogMap
 const FOG_SOURCE_NAME := "fog"
 
 var tile_map: TileMap
-var layer: int
+var layer: TileMapLayer
 var source_id: int = -1
 
-func _init(tile_map: TileMap, fog_layer: int) -> void:
+func _init(tile_map: TileMap, fog_layer: TileMapLayer) -> void:
     self.tile_map = tile_map
     self.layer = fog_layer
     var tset: TileSet = tile_map.tile_set
@@ -19,10 +19,10 @@ func _init(tile_map: TileMap, fog_layer: int) -> void:
     source_id = _get_or_create_fog_source(tset)
 
 func set_fog(coord: Vector2i) -> void:
-    tile_map.set_cell(layer, coord, source_id)
+    layer.set_cell(coord, source_id)
 
 func clear_fog(coord: Vector2i) -> void:
-    tile_map.erase_cell(layer, coord)
+    layer.erase_cell(coord)
 
 ## Generates a fog texture based on the TileSet tile size.
 func _generate_fog_texture(size: Vector2i) -> Texture2D:

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -12,9 +12,9 @@ signal tile_clicked(qr:Vector2i)
 
 
 @onready var grid: TileMap = $TileMap
-var terrain_layer: int = -1
-var buildings_layer: int = -1
-var fog_layer: int = -1
+@onready var terrain_layer: TileMapLayer = $TileMap/Terrain
+@onready var buildings_layer: TileMapLayer = $TileMap/Buildings
+@onready var fog_layer: TileMapLayer = $TileMap/Fog
 var fog: FogMap
 
 var _terrain_sources: Dictionary = {}
@@ -42,30 +42,11 @@ func _ready() -> void:
     else:
         _draw_from_saved(_state.tiles)
     reveal_area(Vector2i.ZERO, 2)
-    if fog != null:
-        for coord in _state.tiles.keys():
-            if HexUtils.axial_distance(coord, Vector2i.ZERO) <= 2:
-                fog.clear_fog(coord)
 
 func _setup_layers() -> void:
-    terrain_layer = grid.get_layer_by_name("Terrain")
-    if terrain_layer == -1:
-        grid.add_layer(-1)
-        terrain_layer = grid.get_layers_count() - 1
-        grid.set_layer_name(terrain_layer, "Terrain")
-    grid.set_layer_z_index(terrain_layer, 0)
-    buildings_layer = grid.get_layer_by_name("Buildings")
-    if buildings_layer == -1:
-        grid.add_layer(-1)
-        buildings_layer = grid.get_layers_count() - 1
-        grid.set_layer_name(buildings_layer, "Buildings")
-    grid.set_layer_z_index(buildings_layer, 2)
-    fog_layer = grid.get_layer_by_name("Fog")
-    if fog_layer == -1:
-        grid.add_layer(-1)
-        fog_layer = grid.get_layers_count() - 1
-        grid.set_layer_name(fog_layer, "Fog")
-    grid.set_layer_z_index(fog_layer, 1)
+    terrain_layer.z_index = 0
+    buildings_layer.z_index = 2
+    fog_layer.z_index = 1
     fog = FogMap.new(grid, fog_layer)
 
 func _setup_tileset() -> void:
@@ -160,12 +141,12 @@ func _set_tile(coord: Vector2i) -> void:
     var data: Dictionary = _state.tiles.get(coord, {})
     var terrain_name: String = data.get("terrain", "forest")
     var source_id: int = _terrain_sources.get(terrain_name, _terrain_sources.get("forest"))
-    grid.set_cell(terrain_layer, coord, source_id)
+    terrain_layer.set_cell(coord, source_id)
     var bname: String = data.get("building", "")
     if bname != "" and _building_sources.has(bname):
-        grid.set_cell(buildings_layer, coord, _building_sources[bname])
+        buildings_layer.set_cell(coord, _building_sources[bname])
     else:
-        grid.erase_cell(buildings_layer, coord)
+        buildings_layer.erase_cell(coord)
     var marker: Node2D = _markers.get(coord, null)
     if data.get("hostile", false):
         if marker == null:

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -14,6 +14,16 @@ class DummyHexMap:
     func _setup_tileset() -> void:
         pass
 
+    func _setup_layers() -> void:
+        pass
+
+    func _ready() -> void:
+        _ensure_singletons()
+        if GameState.tiles.is_empty():
+            _generate_tiles()
+        else:
+            _draw_from_saved(GameState.tiles)
+
     func reveal_area(center: Vector2i, reveal_radius: int = 2) -> void:
         for coord in GameState.tiles.keys():
             if HexUtils.axial_distance(coord, center) <= reveal_radius:


### PR DESCRIPTION
## Summary
- Restructure world scene with dedicated Terrain, Buildings, and Fog TileMapLayer children.
- Refactor HexMap to target layer nodes, preserve existing tiles, and reveal a radius-2 area.
- Update FogMap to operate on TileMapLayer nodes.

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4-server` *(fails: Unable to locate package godot4-server)*

------
https://chatgpt.com/codex/tasks/task_e_68c25d9db968833082636fe670eea91a