### PR TITLE
fix: clean up 4.4.1 build warnings

### DIFF
--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -5,12 +5,12 @@ class_name FogMap
 const FOG_SOURCE_NAME := "fog"
 
 var tile_map: TileMap
-var layer: TileMapLayer
+var fog_layer: TileMapLayer
 var source_id: int = -1
 
-func _init(tile_map: TileMap, fog_layer: TileMapLayer) -> void:
-    self.tile_map = tile_map
-    self.layer = fog_layer
+func _init(p_tile_map: TileMap, p_fog_layer: TileMapLayer) -> void:
+    tile_map = p_tile_map
+    fog_layer = p_fog_layer
     var tset: TileSet = tile_map.tile_set
     if tset == null:
         tset = TileSet.new()
@@ -19,10 +19,10 @@ func _init(tile_map: TileMap, fog_layer: TileMapLayer) -> void:
     source_id = _get_or_create_fog_source(tset)
 
 func set_fog(coord: Vector2i) -> void:
-    layer.set_cell(coord, source_id)
+    fog_layer.set_cell(coord, source_id)
 
 func clear_fog(coord: Vector2i) -> void:
-    layer.erase_cell(coord)
+    fog_layer.erase_cell(coord)
 
 ## Generates a fog texture based on the TileSet tile size.
 func _generate_fog_texture(size: Vector2i) -> Texture2D:

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -95,11 +95,9 @@ func _setup_building_tiles() -> void:
         img.blit_rect(inner, Rect2i(Vector2i.ZERO, inner.get_size()), Vector2i(12, 12))
         var big := Image.create(size.x, size.y, false, Image.FORMAT_RGBA8)
         big.fill(Color(0, 0, 0, 0))
-        # Godot 4 uses "//" for integer division, but some tooling may not
-        # recognize it, causing parse errors. Use explicit casts to ensure
-        # compatibility with environments that only support "/".
-        var off_x := int((size.x - img.get_width()) / 2)
-        var off_y := int((size.y - img.get_height()) / 2)
+        # integer division: center building icon
+        var off_x := (size.x - img.get_width()) // 2
+        var off_y := (size.y - img.get_height()) // 2
         var off := Vector2i(off_x, off_y)
         big.blit_rect(img, Rect2i(Vector2i.ZERO, img.get_size()), off)
         var tex := ImageTexture.create_from_image(big)

--- a/scripts/world/RaiderManager.gd
+++ b/scripts/world/RaiderManager.gd
@@ -21,7 +21,6 @@ func process_tick() -> void:
 
 func _spawn_raiders() -> void:
     for coord in GameState.hostile_tiles:
-        var tile: Dictionary = GameState.tiles.get(coord, {})
         var target: Vector2i = _find_target(coord)
         var path: Array[Vector2i] = Pathing.bfs_path(coord, target, func(p: Vector2i):
             return GameState.tiles.has(p) and GameState.tiles[p].get("terrain") != "lake"


### PR DESCRIPTION
## Summary
- avoid shadowing `tile_map` parameter and use `TileMapLayer` for fog
- use explicit integer division for building icon offsets
- drop unused variable when spawning raiders

## Testing
- `godot4 --headless --run tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c25f1b737083308c3626c713389f9f