### PR TITLE
Fix HexMap integer division syntax

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -95,9 +95,9 @@ func _setup_building_tiles() -> void:
         img.blit_rect(inner, Rect2i(Vector2i.ZERO, inner.get_size()), Vector2i(12, 12))
         var big := Image.create(size.x, size.y, false, Image.FORMAT_RGBA8)
         big.fill(Color(0, 0, 0, 0))
-        # integer division: center building icon
-        var off_x := (size.x - img.get_width()) // 2
-        var off_y := (size.y - img.get_height()) // 2
+        # center building icon with integer division
+        var off_x := int((size.x - img.get_width()) / 2)
+        var off_y := int((size.y - img.get_height()) / 2)
         var off := Vector2i(off_x, off_y)
         big.blit_rect(img, Rect2i(Vector2i.ZERO, img.get_size()), off)
         var tex := ImageTexture.create_from_image(big)


### PR DESCRIPTION
## Summary
- Replace unsupported `//` operator in HexMap's building tile setup with explicit integer cast

## Testing
- `Godot_v4.2.2-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: Could not resolve class "HexMap" and missing preload files)*

------
https://chatgpt.com/codex/tasks/task_e_68c2604e428c8330aaec6bc56d1439dc