### PR TITLE
Use string check for existing building

### DIFF
--- a/scripts/ui/Main.gd
+++ b/scripts/ui/Main.gd
@@ -48,7 +48,7 @@ func _on_build_pressed() -> void:
     if not GameState.tiles.has(_last_clicked):
         return
     var tile: Dictionary = GameState.tiles[_last_clicked]
-    if tile.get("building") != null:
+    if tile.get("building", "") != "":
         return
     var cost: Dictionary = _selected_building.get_construction_cost()
     for res in cost.keys():


### PR DESCRIPTION
## Summary
- prevent building placement on occupied tiles by checking building field against empty string

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c267125ac4833080dbe076b691af9b