### PR TITLE
Handle missing building key when finding raider targets

### DIFF
--- a/scripts/world/RaiderManager.gd
+++ b/scripts/world/RaiderManager.gd
@@ -77,7 +77,7 @@ func _find_target(start: Vector2i) -> Vector2i:
     if candidates.is_empty():
         for coord in GameState.tiles.keys():
             var tile: Dictionary = GameState.tiles[coord]
-            if tile.get("owner", "") == "player" and tile.get("building") != null:
+            if tile.get("owner", "") == "player" and tile.get("building", "") != "":
                 candidates.append(coord)
     if candidates.is_empty():
         return Vector2i.ZERO


### PR DESCRIPTION
## Summary
- avoid null building values when selecting raider targets

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2687a948c833081341d4adaffb9d8