### PR TITLE
Remove unused terrain layer from HexMap

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -1,9 +1,8 @@
 extends Node2D
 class_name HexMap
 
-@onready var grid: TileMap         = $TileMap
-@onready var terrain: TileMapLayer = $TileMap/Terrain
-@onready var fog: TileMapLayer     = $TileMap/Fog
+@onready var grid: TileMap     = $TileMap
+@onready var fog: TileMapLayer = $TileMap/Fog
 
 signal tile_clicked(cell: Vector2i)
 


### PR DESCRIPTION
## Summary
- drop unused `terrain` layer reference to avoid warnings

## Testing
- `/tmp/godot4/Godot_v4.2.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: Could not resolve class `HexMap` and other parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c26c34d88883309b2c80ba75c5255d