### PR TITLE
Use global Resources class

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -5,21 +5,20 @@ const MAKKARA_PER_TICK := 0.1
 const LOYLY_PER_TICK := 0.2
 const SPEED_PER_SAUNAKUNNIA := 0.25
 
-const ResourcesLib = preload("res://scripts/core/Resources.gd")
 const SaunakunniaLib = preload("res://scripts/core/Saunakunnia.gd")
 const BuildingLib = preload("res://scripts/core/Building.gd")
 
 var res := {
-    ResourcesLib.HALOT: 0.0,
-    ResourcesLib.MAKKARA: 0.0,
-    ResourcesLib.KIUASKIVET: 0.0,
-    ResourcesLib.SAUNATIETO: 0.0,
-    ResourcesLib.LAUDEVALTA: 0.0,
-    ResourcesLib.LOYLY: 0.0,
-    ResourcesLib.SISU: 0.0,
-    ResourcesLib.SAUNATUNNELMA: 100.0,
-    ResourcesLib.KULTA: 100.0,
-    ResourcesLib.SAUNAKUNNIA: 0.0,
+    Resources.HALOT: 0.0,
+    Resources.MAKKARA: 0.0,
+    Resources.KIUASKIVET: 0.0,
+    Resources.SAUNATIETO: 0.0,
+    Resources.LAUDEVALTA: 0.0,
+    Resources.LOYLY: 0.0,
+    Resources.SISU: 0.0,
+    Resources.SAUNATUNNELMA: 100.0,
+    Resources.KULTA: 100.0,
+    Resources.SAUNAKUNNIA: 0.0,
 }
 
 var production_modifier: float = 1.0
@@ -39,10 +38,10 @@ func _ready() -> void:
     GameClock.tick.connect(_on_tick)
 
 func _on_tick() -> void:
-    var mult := production_modifier * SaunakunniaLib.production_bonus(int(res.get(ResourcesLib.SAUNAKUNNIA, 0)))
-    res[ResourcesLib.HALOT] += HALOT_PER_TICK * mult
-    res[ResourcesLib.MAKKARA] += MAKKARA_PER_TICK * mult
-    res[ResourcesLib.LOYLY] += LOYLY_PER_TICK * mult
+    var mult := production_modifier * SaunakunniaLib.production_bonus(int(res.get(Resources.SAUNAKUNNIA, 0)))
+    res[Resources.HALOT] += HALOT_PER_TICK * mult
+    res[Resources.MAKKARA] += MAKKARA_PER_TICK * mult
+    res[Resources.LOYLY] += LOYLY_PER_TICK * mult
     if modifier_ticks_remaining > 0:
         modifier_ticks_remaining -= 1
         if modifier_ticks_remaining <= 0:
@@ -94,8 +93,8 @@ func load_state() -> void:
         last_timestamp = int(Time.get_unix_time_from_system())
         return
     res = data.get("res", res)
-    res[ResourcesLib.SISU] = min(10.0, res.get(ResourcesLib.SISU, 0.0))
-    res[ResourcesLib.SAUNATUNNELMA] = max(0.0, res.get(ResourcesLib.SAUNATUNNELMA, 0.0))
+    res[Resources.SISU] = min(10.0, res.get(Resources.SISU, 0.0))
+    res[Resources.SAUNATUNNELMA] = max(0.0, res.get(Resources.SAUNATUNNELMA, 0.0))
     tutorial_done = bool(data.get("tutorial_done", false))
     last_timestamp = int(data.get("last_timestamp", Time.get_unix_time_from_system()))
     tiles.clear()
@@ -130,10 +129,10 @@ func load_state() -> void:
     if elapsed > 0:
         var ticks := int(elapsed / GameClock.TICK_INTERVAL)
         if ticks > 0:
-            var mult := SaunakunniaLib.production_bonus(int(res.get(ResourcesLib.SAUNAKUNNIA, 0)))
-            res[ResourcesLib.HALOT] += HALOT_PER_TICK * ticks * mult
-            res[ResourcesLib.MAKKARA] += MAKKARA_PER_TICK * ticks * mult
-            res[ResourcesLib.LOYLY] += LOYLY_PER_TICK * ticks * mult
+            var mult := SaunakunniaLib.production_bonus(int(res.get(Resources.SAUNAKUNNIA, 0)))
+            res[Resources.HALOT] += HALOT_PER_TICK * ticks * mult
+            res[Resources.MAKKARA] += MAKKARA_PER_TICK * ticks * mult
+            res[Resources.LOYLY] += LOYLY_PER_TICK * ticks * mult
     last_timestamp = now
     _apply_speed_for_saunakunnia()
     save()
@@ -142,9 +141,9 @@ func load() -> void:
     load_state()
 
 func gain_saunakunnia() -> void:
-    res[ResourcesLib.SAUNAKUNNIA] += 1
+    res[Resources.SAUNAKUNNIA] += 1
     for k in res.keys():
-        if k != ResourcesLib.SAUNAKUNNIA:
+        if k != Resources.SAUNAKUNNIA:
             res[k] = 0.0
     production_modifier = 1.0
     modifier_ticks_remaining = 0
@@ -152,7 +151,7 @@ func gain_saunakunnia() -> void:
     save()
 
 func _apply_speed_for_saunakunnia() -> void:
-    var saunakunnia_level: int = int(res.get(ResourcesLib.SAUNAKUNNIA, 0))
+    var saunakunnia_level: int = int(res.get(Resources.SAUNAKUNNIA, 0))
     GameClock.set_speed(1.0 + saunakunnia_level * SPEED_PER_SAUNAKUNNIA)
 
 func set_hostile(coord: Vector2i, hostile: bool) -> void:
@@ -174,10 +173,10 @@ func update_hostile_tiles() -> void:
             hostile_tiles.append(c)
 
 func add_sisu(amount: float) -> void:
-    var current: float = res.get(ResourcesLib.SISU, 0.0)
-    res[ResourcesLib.SISU] = min(10.0, current + amount)
+    var current: float = res.get(Resources.SISU, 0.0)
+    res[Resources.SISU] = min(10.0, current + amount)
 
 func decrease_saunatunnelma(amount: float) -> void:
-    var current: float = res.get(ResourcesLib.SAUNATUNNELMA, 0.0)
-    res[ResourcesLib.SAUNATUNNELMA] = max(0.0, current - amount)
+    var current: float = res.get(Resources.SAUNATUNNELMA, 0.0)
+    res[Resources.SAUNATUNNELMA] = max(0.0, current - amount)
 

--- a/tests/test_battle.gd
+++ b/tests/test_battle.gd
@@ -1,7 +1,5 @@
 extends Node
 
-var Resources = preload("res://scripts/core/Resources.gd")
-
 func _remove_save(gs) -> void:
     if FileAccess.file_exists(gs.SAVE_PATH):
         DirAccess.remove_absolute(gs.SAVE_PATH)

--- a/tests/test_building.gd
+++ b/tests/test_building.gd
@@ -1,6 +1,5 @@
 extends Node
 var Building = preload("res://scripts/core/Building.gd")
-var Resources = preload("res://scripts/core/Resources.gd")
 
 func test_upgrade_increments_level(res):
     var building = Building.new()

--- a/tests/test_game_state.gd
+++ b/tests/test_game_state.gd
@@ -1,6 +1,4 @@
 extends Node
-
-var Resources = preload("res://scripts/core/Resources.gd")
 func _remove_save(gs) -> void:
     if FileAccess.file_exists(gs.SAVE_PATH):
         DirAccess.remove_absolute(gs.SAVE_PATH)

--- a/tests/test_raiders.gd
+++ b/tests/test_raiders.gd
@@ -1,7 +1,5 @@
 extends Node
 
-var Resources = preload("res://scripts/core/Resources.gd")
-
 func _setup_world():
     var tree = Engine.get_main_loop()
     var gs = tree.root.get_node("GameState")

--- a/tests/test_sisu.gd
+++ b/tests/test_sisu.gd
@@ -1,7 +1,5 @@
 extends Node
 
-var Resources = preload("res://scripts/core/Resources.gd")
-
 func _remove_save(gs) -> void:
     if FileAccess.file_exists(gs.SAVE_PATH):
         DirAccess.remove_absolute(gs.SAVE_PATH)


### PR DESCRIPTION
## Summary
- standardize resource key access to use global `Resources` class
- drop manual `Resources` preloads from tests

## Testing
- `godot3-server --path . -s tests/test_runner.gd` *(fails: project requires newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68c27195985c8330b44190ed7dfa83b4