### PR TITLE
Guard Sisu healing when Units node missing

### DIFF
--- a/scripts/systems/SisuSystem.gd
+++ b/scripts/systems/SisuSystem.gd
@@ -25,10 +25,14 @@ func spend() -> bool:
     return true
 
 func _heal_units() -> void:
+    var units_root: Node = null
+    if world:
+        units_root = world.get_node_or_null("Units")
+    if units_root == null:
+        return
     var nodes_by_id: Dictionary = {}
-    if world and world.has_node("Units"):
-        for child in world.units_root.get_children():
-            nodes_by_id[child.id] = child
+    for child in units_root.get_children():
+        nodes_by_id[child.id] = child
     for i in range(GameState.units.size()):
         var data: Dictionary = GameState.units[i]
         var uid: String = data.get("id", "")

--- a/tests/test_sisu.gd
+++ b/tests/test_sisu.gd
@@ -52,3 +52,30 @@ func test_spend_sisu_heals(res) -> void:
         _cleanup(world, sisu, gs, orig)
         return
     _cleanup(world, sisu, gs, orig)
+
+func test_spend_sisu_without_units(res) -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    _remove_save(gs)
+    var orig = gs.res.duplicate()
+    gs.units.clear()
+    gs.tiles.clear()
+    gs.res[Resources.SISU] = 5.0
+    var world = Node.new()
+    var SisuSystem = load("res://scripts/systems/SisuSystem.gd")
+    var sisu = SisuSystem.new()
+    sisu.world = world
+    tree.root.add_child(sisu)
+    if not sisu.spend():
+        res.fail("Spend failed")
+        _cleanup(world, sisu, gs, orig)
+        return
+    if gs.res[Resources.SISU] != 0.0:
+        res.fail("Sisu not deducted")
+        _cleanup(world, sisu, gs, orig)
+        return
+    if sisu.cooldown_ticks_remaining <= 0:
+        res.fail("Cooldown not active")
+        _cleanup(world, sisu, gs, orig)
+        return
+    _cleanup(world, sisu, gs, orig)


### PR DESCRIPTION
## Summary
- Use `world.get_node_or_null("Units")` and exit early if missing in `SisuSystem` healing logic
- Add test covering Sisu spending when no Units node exists

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c27707daac83309e357b760b14d65b