### PR TITLE
Add Torille ability to recall units to saunas

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ Mouse-only prototype:
 - Center: hex-grid map & battle
 - Right: policies/events
 - Sisu button: clutch play
+- Torille! button: recall units to nearest sauna

--- a/scenes/ui/Main.tscn
+++ b/scenes/ui/Main.tscn
@@ -47,3 +47,8 @@ position = Vector2(0,60)
 text = "Spend Sisu"
 tooltip_text = "Heal team 20% (5 Sisu, 10s cd)"
 
+[node name="TorilleButton" type="Button" parent="DebugUI"]
+position = Vector2(0,90)
+text = "Torille!"
+tooltip_text = "Recall units to nearest sauna (5 Sisu, 10s cd)"
+

--- a/scripts/systems/SisuSystem.gd
+++ b/scripts/systems/SisuSystem.gd
@@ -24,6 +24,15 @@ func spend() -> bool:
     _heal_units()
     return true
 
+func torille() -> bool:
+    if not can_spend():
+        return false
+    GameState.res[Resources.SISU] = GameState.res.get(Resources.SISU, 0.0) - 5.0
+    cooldown_ticks_remaining = COOLDOWN_TICKS
+    if world and world.has_method("torille"):
+        world.torille()
+    return true
+
 func _heal_units() -> void:
     var units_root: Node = null
     if world:

--- a/scripts/ui/Main.gd
+++ b/scripts/ui/Main.gd
@@ -7,6 +7,7 @@ const TutorialOverlayScene = preload("res://scenes/ui/TutorialOverlay.tscn")
 @onready var reveal_btn: Button = $DebugUI/RevealAllButton
 @onready var spawn_btn: Button = $DebugUI/SpawnButton
 @onready var sisu_btn: Button = $DebugUI/SpendSisuButton
+@onready var torille_btn: Button = $DebugUI/TorilleButton
 @onready var sisu_system: Node = $SisuSystem
 
 var _selected_building: Building = null
@@ -29,15 +30,16 @@ func _ready() -> void:
     reveal_btn.pressed.connect(_on_reveal_all)
     spawn_btn.pressed.connect(_on_spawn)
     sisu_btn.pressed.connect(_on_sisu_pressed)
+    torille_btn.pressed.connect(_on_torille_pressed)
     sisu_system.world = world
     hud.update_resources(GameState.res)
-    _update_sisu_button()
+    _update_sisu_buttons()
     if not GameState.tutorial_done:
         start_tutorial()
 
 func _on_game_tick() -> void:
     hud.update_resources(GameState.res)
-    _update_sisu_button()
+    _update_sisu_buttons()
 
 func _on_building_selected(building_name: String) -> void:
     _selected_building = _buildings.get(building_name, null)
@@ -79,10 +81,17 @@ func _on_spawn() -> void:
 func _on_sisu_pressed() -> void:
     if sisu_system.spend():
         hud.update_resources(GameState.res)
-    _update_sisu_button()
+    _update_sisu_buttons()
 
-func _update_sisu_button() -> void:
-    sisu_btn.disabled = not sisu_system.can_spend()
+func _on_torille_pressed() -> void:
+    if sisu_system.torille():
+        hud.update_resources(GameState.res)
+    _update_sisu_buttons()
+
+func _update_sisu_buttons() -> void:
+    var disabled := not sisu_system.can_spend()
+    sisu_btn.disabled = disabled
+    torille_btn.disabled = disabled
 
 func start_tutorial() -> void:
     if _tutorial_overlay:

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -24,6 +24,7 @@ var test_script_paths := [
     "res://tests/test_battle.gd",
     "res://tests/test_raiders.gd",
     "res://tests/test_sisu.gd",
+    "res://tests/test_torille.gd",
 ]
 
 func _init() -> void:

--- a/tests/test_torille.gd
+++ b/tests/test_torille.gd
@@ -1,0 +1,35 @@
+extends Node
+
+func _remove_save(gs) -> void:
+    if FileAccess.file_exists(gs.SAVE_PATH):
+        DirAccess.remove_absolute(gs.SAVE_PATH)
+
+func test_torille_recall(res) -> void:
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    _remove_save(gs)
+    gs.units.clear()
+    gs.tiles.clear()
+    gs.tiles[Vector2i(0,0)] = {"terrain":"grass", "building":"sauna"}
+    gs.tiles[Vector2i(1,0)] = {"terrain":"grass"}
+    gs.tiles[Vector2i(2,0)] = {"terrain":"grass"}
+    var world_scene: PackedScene = load("res://scenes/world/World.tscn")
+    var world = world_scene.instantiate()
+    tree.root.add_child(world)
+    world.spawn_unit_at_center()
+    var unit = world.get_node("Units").get_child(0)
+    unit.pos_qr = Vector2i(2,0)
+    unit.position = world.hex_map.axial_to_world(unit.pos_qr)
+    for i in range(GameState.units.size()):
+        var data: Dictionary = GameState.units[i]
+        if data.get("id", "") == unit.id:
+            data["pos_qr"] = unit.pos_qr
+            GameState.units[i] = data
+            break
+    world.torille()
+    if unit.pos_qr != Vector2i(0,0):
+        res.fail("unit not recalled")
+    world.queue_free()
+    gs.units.clear()
+    gs.tiles.clear()
+    _remove_save(gs)


### PR DESCRIPTION
## Summary
- Add Torille ability consuming Sisu to recall units to their nearest sauna
- Wire up new Torille button in UI and Sisu system
- Cover Torille behavior with a unit test

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found: godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68c279c4b70883308b5b457ac5f20336