### PR TITLE
Emit tile click signal

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -6,6 +6,11 @@ class_name HexMap
 
 signal tile_clicked(cell: Vector2i)
 
+func _unhandled_input(event: InputEvent) -> void:
+    if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+        var cell := grid.local_to_map(grid.to_local(event.position))
+        emit_signal("tile_clicked", cell)
+
 func axial_to_world(qr: Vector2i) -> Vector2:
     return grid.map_to_local(qr)
 


### PR DESCRIPTION
## Summary
- Emit `tile_clicked` from HexMap when the player presses the left mouse button

## Testing
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Identifier "Resources" not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a7a29184833087c704a99f650d84