### PR TITLE
Specify bool type for sisu button toggle

### DIFF
--- a/scripts/ui/Main.gd
+++ b/scripts/ui/Main.gd
@@ -89,7 +89,7 @@ func _on_torille_pressed() -> void:
     _update_sisu_buttons()
 
 func _update_sisu_buttons() -> void:
-    var disabled := not sisu_system.can_spend()
+    var disabled: bool = not sisu_system.can_spend()
     sisu_btn.disabled = disabled
     torille_btn.disabled = disabled
 


### PR DESCRIPTION
## Summary
- Fix type inference error in `_update_sisu_buttons` by declaring `disabled` as `bool`

## Testing
- `godot3 --headless -s tests/test_runner.gd` (fails: Can't open project; config_version 5 requires newer engine)
- `/tmp/godot4/Godot_v4.2.2-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` (fails: Parse Error: Identifier "Resources" not declared in the current scope)


------
https://chatgpt.com/codex/tasks/task_e_68c2bbd5ea9c83308c3d22ed36015fcd