### PR TITLE
Reveal starting area on world load

### DIFF
--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -16,6 +16,7 @@ var raider_manager: RaiderManager
 
 func _ready() -> void:
     cam.position = grid.map_to_local(Vector2i(0, 0))
+    hex_map.reveal_area(Vector2i(0, 0), 2)
     raider_manager = RaiderManager.new()
     add_child(raider_manager)
     raider_manager.setup(hex_map, units_root, unit_scene)


### PR DESCRIPTION
## Summary
- Reveal hex map fog of war around the origin when the world node is ready

## Testing
- `./godot4/Godot_v4.2.2-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Identifier "Resources" not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c85fa9f88330b45e10b5847d64b6