### PR TITLE
Reduce fog opacity

### DIFF
--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -22,5 +22,6 @@ cell_tile_size = Vector2i(96, 84)
 [node name="Buildings" type="TileMapLayer" parent="HexMap/TileMap"]
 
 [node name="Fog" type="TileMapLayer" parent="HexMap/TileMap"]
+modulate = Color(1, 1, 1, 0.55)
 
 [node name="Units" type="Node2D" parent="."]

--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -27,7 +27,7 @@ func clear_fog(coord: Vector2i) -> void:
 ## Generates a fog texture based on the TileSet tile size.
 func _generate_fog_texture(size: Vector2i) -> Texture2D:
     var img := Image.create(size.x, size.y, false, Image.FORMAT_RGBA8)
-    img.fill(Color(0, 0, 0, 0.75))
+    img.fill(Color(0, 0, 0, 0.55))
     return ImageTexture.create_from_image(img)
 
 ## Returns an existing fog source or creates one if absent.
@@ -40,5 +40,6 @@ func _get_or_create_fog_source(tset: TileSet) -> int:
     var src := TileSetAtlasSource.new()
     src.resource_name = FOG_SOURCE_NAME
     src.texture = _generate_fog_texture(size)
+    src.modulate = Color(1, 1, 1, 0.55)
     src.texture_region_size = size
     return tset.add_source(src)


### PR DESCRIPTION
## Summary
- Make fog texture semi-transparent with 55% alpha and apply matching modulate
- Modulate Fog layer to keep translucency consistent

## Testing
- `./Godot_v4.2.2-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Parse Error: Identifier "Resources" not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cac5c28483308abc8a1b26eb3def