### PR TITLE
Type dictionary variables in HexMap reveal methods

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -35,15 +35,15 @@ func axial_to_world(qr: Vector2i) -> Vector2:
 func reveal_area(center: Vector2i, reveal_radius: int = 2) -> void:
     for cell in _disc(center, reveal_radius):
         fog.erase_cell(cell)
-        var t := GameState.tiles.get(cell, null)
-        if t:
+        var t: Dictionary = GameState.tiles.get(cell, null)
+        if t != null:
             t["explored"] = true
             GameState.tiles[cell] = t
 
 func reveal_all() -> void:
     fog.clear()
     for coord in GameState.tiles.keys():
-        var t := GameState.tiles[coord]
+        var t: Dictionary = GameState.tiles[coord]
         t["explored"] = true
         GameState.tiles[coord] = t
 


### PR DESCRIPTION
## Summary
- add explicit Dictionary typing and null check for reveal_area
- type dictionary variable in reveal_all

## Testing
- `godot3 --headless --path . -s tests/test_runner.gd` *(fails: project requires newer Godot engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c30747cda48330935a38d57bfc72ce