### PR TITLE
Fix Node type for root in HexMap

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -109,7 +109,7 @@ func _disc(center: Vector2i, radius: int) -> Array[Vector2i]:
     return cells
 
 func _ensure_singletons() -> void:
-    var root := Engine.get_main_loop().root
+    var root: Node = Engine.get_main_loop().root
     load("res://scripts/core/Resources.gd")
     if not root.has_node("GameState"):
         var gs = load("res://autoload/GameState.gd").new()


### PR DESCRIPTION
## Summary
- type root variable as Node in `_ensure_singletons` to fix parse error

## Testing
- `godot --headless --check-only` *(fails: command not found; attempted installation but package/binary unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c414a03ab083309daf4cc69850debd