### PR TITLE
Add farm building resource

### DIFF
--- a/resources/buildings/farm.tres
+++ b/resources/buildings/farm.tres
@@ -1,0 +1,3 @@
+[gd_resource type="Resource" format=3 uid="uid://ae75569d1df0"]
+
+[resource]


### PR DESCRIPTION
## Summary
- add missing `farm.tres` building resource so tests can preload it

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: Identifier "Resources" not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68c417440fa88330b501ba74c04f9e18