### PR TITLE
fix: guard hex tile reveal

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -35,8 +35,8 @@ func axial_to_world(qr: Vector2i) -> Vector2:
 func reveal_area(center: Vector2i, reveal_radius: int = 2) -> void:
     for cell in _disc(center, reveal_radius):
         fog.erase_cell(cell)
-        var t: Dictionary = GameState.tiles.get(cell, null)
-        if t != null:
+        if GameState.tiles.has(cell):
+            var t: Dictionary = GameState.tiles[cell]
             t["explored"] = true
             GameState.tiles[cell] = t
 


### PR DESCRIPTION
## Summary
- avoid assigning null to a Dictionary in `reveal_area`

## Testing
- `godot3-server --path . -s tests/test_runner.gd` *(fails: project requires a more recent engine version)*

------
https://chatgpt.com/codex/tasks/task_e_68c41919465c8330b7ed9ae3b0ed37b2