### PR TITLE
Clarify resource snapshot type in event test

### DIFF
--- a/tests/test_events.gd
+++ b/tests/test_events.gd
@@ -101,7 +101,7 @@ func test_unaffordable_choice_keeps_resources(res) -> void:
     gs.res[Resources.HALOT] = 0.0
     var ev: GameEventBase = load("res://resources/events/merchant.tres")
     em.start_event(ev)
-    var before := gs.res.duplicate()
+    var before: Dictionary = gs.res.duplicate()
     em._on_choice_selected(ev.choices[0])
     _cleanup_overlays(tree)
     if gs.res != before:


### PR DESCRIPTION
## Summary
- Specify Dictionary type for `before` snapshot in `test_unaffordable_choice_keeps_resources`

## Testing
- `gdparse tests/test_events.gd && echo 'Parsed OK'`


------
https://chatgpt.com/codex/tasks/task_e_68c41a37d6308330a34ead58ed29bfb9