### PR TITLE
Specify Array type for resource keys

### DIFF
--- a/tests/test_resources.gd
+++ b/tests/test_resources.gd
@@ -2,7 +2,7 @@ extends Node
 
 func test_game_state_resources(res) -> void:
     var gs = Engine.get_main_loop().root.get_node("GameState")
-    var keys := gs.res.keys()
+    var keys: Array = gs.res.keys()
     keys.sort()
     var expected := [
         Resources.HALOT,


### PR DESCRIPTION
## Summary
- annotate `keys` in resource test as `Array`

## Testing
- `godot_v4.4.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: Parse Error: Identifier "Resources" not declared in the current scope)*

------
https://chatgpt.com/codex/tasks/task_e_68c41b108b40833082c12584cca39731