### PR TITLE
Add explicit float type to saunakunnia bonus test

### DIFF
--- a/tests/test_saunakunnia.gd
+++ b/tests/test_saunakunnia.gd
@@ -19,6 +19,6 @@ func test_saunakunnia_bonus(res) -> void:
     gs.res[Resources.HALOT] = 0.0
     gs.res[Resources.SAUNAKUNNIA] = 2.0
     gs._on_tick()
-    var expected := gs.HALOT_PER_TICK * (1.0 + 0.2)
+    var expected: float = gs.HALOT_PER_TICK * (1.0 + 0.2)
     if abs(gs.res[Resources.HALOT] - expected) > 0.001:
         res.fail("saunakunnia bonus not applied")


### PR DESCRIPTION
## Summary
- annotate saunakunnia bonus test with explicit `float` type for expected value

## Testing
- `gdlint tests/test_saunakunnia.gd`

------
https://chatgpt.com/codex/tasks/task_e_68c41c8756548330beaa073dad319a5f