### PR TITLE
Cast loaded event and policy resources in tests

### DIFF
--- a/tests/test_action.gd
+++ b/tests/test_action.gd
@@ -8,7 +8,10 @@ func test_policy_apply_and_cooldown(res):
     gs.res[Resources.KULTA] = 100.0
     gs.res[Resources.SAUNATUNNELMA] = 0.0
     gs.res[Resources.MAKKARA] = 0.0
-    var policy: Policy = load("res://resources/policies/tax_relief.tres")
+    var policy := load("res://resources/policies/tax_relief.tres") as Policy
+    if policy == null:
+        res.fail("Policy failed to load")
+        return
     if not (policy is Action):
         res.fail("Policy does not inherit Action")
         return
@@ -28,7 +31,10 @@ func test_event_inherits_action(res):
     gs.res[Resources.KULTA] = 100.0
     gs.res[Resources.SAUNATUNNELMA] = 0.0
     gs.res[Resources.MAKKARA] = 0.0
-    var ev: GameEventBase = load("res://resources/events/rain.tres")
+    var ev := load("res://resources/events/rain.tres") as GameEventBase
+    if ev == null:
+        res.fail("Event failed to load")
+        return
     if not (ev is Action):
         res.fail("Event does not inherit Action")
         return
@@ -50,7 +56,11 @@ func test_sauna_diplomacy(res):
     gs.res[Resources.HALOT] = 50.0
     gs.res[Resources.LOYLY] = 1.0
     gs.res[Resources.LAUDEVALTA] = 0.0
-    var ev: GameEventBase = load("res://resources/events/sauna_diplomacy.tres")
+    var ev := load("res://resources/events/sauna_diplomacy.tres") as GameEventBase
+    if ev == null:
+        res.fail("Sauna Diplomacy failed to load")
+        gs.res = orig_res
+        return
     if not ev.can_trigger():
         res.fail("Sauna Diplomacy cannot trigger")
         gs.res = orig_res
@@ -71,7 +81,11 @@ func test_cold_snap(res):
     gs.res[Resources.LOYLY] = 0.0
     gs.production_modifier = 1.0
     gs.modifier_ticks_remaining = 0
-    var ev = load("res://resources/events/cold_snap.tres")
+    var ev := load("res://resources/events/cold_snap.tres") as GameEventBase
+    if ev == null:
+        res.fail("Cold Snap failed to load")
+        _restore(gs, orig_res, orig_mod, orig_ticks)
+        return
     if not ev.apply():
         res.fail("Cold Snap failed to apply without löyly")
         _restore(gs, orig_res, orig_mod, orig_ticks)

--- a/tests/test_events.gd
+++ b/tests/test_events.gd
@@ -20,7 +20,10 @@ func test_branching_event(res) -> void:
     clock.set_process(false)
     gs.res[Resources.HALOT] = 20.0
     gs.res[Resources.MAKKARA] = 0.0
-    var ev: GameEventBase = load("res://resources/events/merchant.tres")
+    var ev := load("res://resources/events/merchant.tres") as GameEventBase
+    if ev == null:
+        res.fail("Merchant event failed to load")
+        return
     em.start_event(ev)
     em._on_choice_selected(ev.choices[0])
     _cleanup_overlays(tree)
@@ -76,7 +79,11 @@ func test_event_fails_prerequisites(res) -> void:
     var em = tree.root.get_node("EventManager")
     var orig = gs.res.duplicate()
     gs.res[Resources.HALOT] = 0.0
-    var ev: GameEventBase = load("res://resources/events/merchant.tres")
+    var ev := load("res://resources/events/merchant.tres") as GameEventBase
+    if ev == null:
+        res.fail("Merchant event failed to load")
+        gs.res = orig
+        return
     if ev.can_trigger():
         res.fail("event unexpectedly triggerable")
         gs.res = orig
@@ -99,7 +106,11 @@ func test_unaffordable_choice_keeps_resources(res) -> void:
     clock.set_process(false)
     var orig = gs.res.duplicate()
     gs.res[Resources.HALOT] = 0.0
-    var ev: GameEventBase = load("res://resources/events/merchant.tres")
+    var ev := load("res://resources/events/merchant.tres") as GameEventBase
+    if ev == null:
+        res.fail("Merchant event failed to load")
+        gs.res = orig
+        return
     em.start_event(ev)
     var before: Dictionary = gs.res.duplicate()
     em._on_choice_selected(ev.choices[0])


### PR DESCRIPTION
## Summary
- Cast policy and event resources to their script classes with null checks to ensure compilation after `GameEvent` inherits `Action`
- Guard event loading in event tests to avoid type errors

## Testing
- `Godot_v4.4.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: Policy failed to load, Event failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_68c41e66eb3883309d106a71a788a49d