### PR TITLE
Add explicit types to test resource copies

### DIFF
--- a/tests/test_action.gd
+++ b/tests/test_action.gd
@@ -4,7 +4,7 @@ const GameEventBase = preload("res://scripts/events/Event.gd")
 
 func test_policy_apply_and_cooldown(res):
     var gs = Engine.get_main_loop().root.get_node("GameState")
-    var orig = gs.res.duplicate()
+    var orig: Dictionary = gs.res.duplicate()
     gs.res[Resources.KULTA] = 100.0
     gs.res[Resources.SAUNATUNNELMA] = 0.0
     gs.res[Resources.MAKKARA] = 0.0
@@ -27,7 +27,7 @@ func test_policy_apply_and_cooldown(res):
 
 func test_event_inherits_action(res):
     var gs = Engine.get_main_loop().root.get_node("GameState")
-    var orig = gs.res.duplicate()
+    var orig: Dictionary = gs.res.duplicate()
     gs.res[Resources.KULTA] = 100.0
     gs.res[Resources.SAUNATUNNELMA] = 0.0
     gs.res[Resources.MAKKARA] = 0.0
@@ -52,7 +52,7 @@ func test_event_inherits_action(res):
 
 func test_sauna_diplomacy(res):
     var gs = Engine.get_main_loop().root.get_node("GameState")
-    var orig_res = gs.res.duplicate()
+    var orig_res: Dictionary = gs.res.duplicate()
     gs.res[Resources.HALOT] = 50.0
     gs.res[Resources.LOYLY] = 1.0
     gs.res[Resources.LAUDEVALTA] = 0.0
@@ -75,7 +75,7 @@ func test_sauna_diplomacy(res):
 
 func test_cold_snap(res):
     var gs = Engine.get_main_loop().root.get_node("GameState")
-    var orig_res = gs.res.duplicate()
+    var orig_res: Dictionary = gs.res.duplicate()
     var orig_mod = gs.production_modifier
     var orig_ticks = gs.modifier_ticks_remaining
     gs.res[Resources.LOYLY] = 0.0

--- a/tests/test_battle.gd
+++ b/tests/test_battle.gd
@@ -8,7 +8,7 @@ func test_battle_player_win(res) -> void:
     var tree = Engine.get_main_loop()
     var gs = tree.root.get_node("GameState")
     _remove_save(gs)
-    var orig = gs.res.duplicate()
+    var orig: Dictionary = gs.res.duplicate()
     gs.units.clear()
     gs.tiles.clear()
     var world_scene: PackedScene = load("res://scenes/world/World.tscn")
@@ -16,7 +16,7 @@ func test_battle_player_win(res) -> void:
     tree.root.add_child(world)
     world.spawn_unit_at_center()
     var target := Vector2i(1, 0)
-    var tdata = gs.tiles.get(target, {})
+    var tdata: Dictionary = gs.tiles.get(target, {})
     tdata["terrain"] = "hill"
     tdata["owner"] = "enemy"
     tdata["hostiles"] = [{"hp":50,"atk":5,"def":1}]
@@ -37,7 +37,7 @@ func test_battle_player_loss(res) -> void:
     var tree = Engine.get_main_loop()
     var gs = tree.root.get_node("GameState")
     _remove_save(gs)
-    var orig = gs.res.duplicate()
+    var orig: Dictionary = gs.res.duplicate()
     gs.units.clear()
     gs.tiles.clear()
     var world_scene: PackedScene = load("res://scenes/world/World.tscn")
@@ -45,7 +45,7 @@ func test_battle_player_loss(res) -> void:
     tree.root.add_child(world)
     world.spawn_unit_at_center()
     var target := Vector2i(1, 0)
-    var tdata = gs.tiles.get(target, {})
+    var tdata: Dictionary = gs.tiles.get(target, {})
     tdata["terrain"] = "forest"
     tdata["owner"] = "enemy"
     tdata["hostiles"] = [{"hp":200,"atk":20,"def":5}]

--- a/tests/test_events.gd
+++ b/tests/test_events.gd
@@ -77,7 +77,7 @@ func test_event_fails_prerequisites(res) -> void:
     var tree = Engine.get_main_loop()
     var gs = tree.root.get_node("GameState")
     var em = tree.root.get_node("EventManager")
-    var orig = gs.res.duplicate()
+    var orig: Dictionary = gs.res.duplicate()
     gs.res[Resources.HALOT] = 0.0
     var ev := load("res://resources/events/merchant.tres") as GameEventBase
     if ev == null:
@@ -104,7 +104,7 @@ func test_unaffordable_choice_keeps_resources(res) -> void:
     var em = tree.root.get_node("EventManager")
     var clock = tree.root.get_node("GameClock")
     clock.set_process(false)
-    var orig = gs.res.duplicate()
+    var orig: Dictionary = gs.res.duplicate()
     gs.res[Resources.HALOT] = 0.0
     var ev := load("res://resources/events/merchant.tres") as GameEventBase
     if ev == null:

--- a/tests/test_raiders.gd
+++ b/tests/test_raiders.gd
@@ -70,7 +70,7 @@ func test_raider_saunatunnelma_hit(res) -> void:
     var world = _setup_world()
     var tree = Engine.get_main_loop()
     var gs = tree.root.get_node("GameState")
-    var orig = gs.res.duplicate()
+    var orig: Dictionary = gs.res.duplicate()
     for i in range(19):
         world._on_game_tick()
     world._on_game_tick()

--- a/tests/test_sisu.gd
+++ b/tests/test_sisu.gd
@@ -16,7 +16,7 @@ func test_spend_sisu_heals(res) -> void:
     var tree = Engine.get_main_loop()
     var gs = tree.root.get_node("GameState")
     _remove_save(gs)
-    var orig = gs.res.duplicate()
+    var orig: Dictionary = gs.res.duplicate()
     gs.units.clear()
     gs.tiles.clear()
     var world_scene: PackedScene = load("res://scenes/world/World.tscn")
@@ -57,7 +57,7 @@ func test_spend_sisu_without_units(res) -> void:
     var tree = Engine.get_main_loop()
     var gs = tree.root.get_node("GameState")
     _remove_save(gs)
-    var orig = gs.res.duplicate()
+    var orig: Dictionary = gs.res.duplicate()
     gs.units.clear()
     gs.tiles.clear()
     gs.res[Resources.SISU] = 5.0


### PR DESCRIPTION
## Summary
- explicitly type resource copies in tests to avoid Variant inference
- annotate tile lookup dictionaries in battle tests

## Testing
- `Godot_v4.3-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Identifier "Resources" not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68c42077eecc8330965b24c7b51ef049