### PR TITLE
Handle empty terrain weights in HexMap

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -99,6 +99,8 @@ func _choose_terrain() -> String:
         roll -= float(terrain_weights[k])
         if roll <= 0.0:
             return k
+    if terrain_weights.is_empty():
+        return "forest"
     return terrain_weights.keys()[0]
 
 func _disc(center: Vector2i, disc_radius: int) -> Array[Vector2i]:


### PR DESCRIPTION
## Summary
- gracefully handle empty terrain weight dictionary in map generation

## Testing
- `godot4 --headless -s tests/test_runner.gd` (fails: command not found)
- `apt-get install -y godot4` (fails: package not found)

------
https://chatgpt.com/codex/tasks/task_e_68c42a98f288833099f7cc680b652df7