### PR TITLE
Attach HUD script to scene

### DIFF
--- a/scenes/ui/Hud.tscn
+++ b/scenes/ui/Hud.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=2 format=3 uid="uid://dkay4i5rdr533"]
+[gd_scene load_steps=3 format=3 uid="uid://dkay4i5rdr533"]
 
+[ext_resource type="Script" uid="uid://dgj0jwslqh22m" path="res://scripts/ui/Hud.gd" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/ui/InfoBox.tscn" id="2"]
 
 [node name="Hud" type="CanvasLayer"]
+script = ExtResource("1")
 
 [node name="ResourcesLabel" type="Label" parent="."]
 text = "Money: 0 Ammo: 0"


### PR DESCRIPTION
## Summary
- link Hud.tscn to its GDScript so start button emits signal

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `godot4 --headless --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c431071c208330800e71b441d11f7f