### PR TITLE
Attach InfoBox script to InfoBox scene

### DIFF
--- a/scenes/ui/InfoBox.tscn
+++ b/scenes/ui/InfoBox.tscn
@@ -1,6 +1,9 @@
-[gd_scene format=3 uid="uid://hr4tr8dsyh61"]
+[gd_scene load_steps=2 format=3 uid="uid://hr4tr8dsyh61"]
+
+[ext_resource type="Script" uid="uid://b4fojisc3w44o" path="res://scripts/ui/InfoBox.gd" id="1"]
 
 [node name="InfoBox" type="Panel"]
+script = ExtResource("1")
 visible = false
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]


### PR DESCRIPTION
## Summary
- assign InfoBox.gd to the InfoBox Panel scene so Hud can access it as InfoBox

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: package not found)*
- `snap install godot4 --classic` *(fails: cannot communicate with server)*

------
https://chatgpt.com/codex/tasks/task_e_68c4326fa180833089fda79ef46e6972