### PR TITLE
Link EventOverlay scene to script

### DIFF
--- a/scenes/ui/EventOverlay.tscn
+++ b/scenes/ui/EventOverlay.tscn
@@ -1,6 +1,9 @@
-[gd_scene format=3 uid="uid://bakkv70rr6dd5"]
+[gd_scene load_steps=2 format=3 uid="uid://bakkv70rr6dd5"]
+
+[ext_resource type="Script" uid="uid://blihb8r8umsqn" path="res://scripts/ui/EventOverlay.gd" id="1"]
 
 [node name="EventOverlay" type="CanvasLayer"]
+script = ExtResource("1")
 
 [node name="Panel" type="Panel" parent="."]
 anchor_left = 0.25


### PR DESCRIPTION
## Summary
- attach `EventOverlay.tscn` root node to `EventOverlay.gd`

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: Identifier "Resources" not declared, parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c433c3a2a08330b815381fe12a2bc2