### PR TITLE
Attach HexTile script to scene root

### DIFF
--- a/scenes/world/HexTile.tscn
+++ b/scenes/world/HexTile.tscn
@@ -1,3 +1,6 @@
-[gd_scene format=3 uid="uid://dtqrobaytfd4p"]
+[gd_scene load_steps=2 format=3 uid="uid://dtqrobaytfd4p"]
+
+[ext_resource type="Script" uid="uid://cke13dhe16soo" path="res://scripts/world/HexTile.gd" id="1"]
 
 [node name="HexTile" type="Node2D"]
+script = ExtResource("1")


### PR DESCRIPTION
## Summary
- Attach HexTile.gd script to the HexTile scene root so MapGenerator can assign hex attributes.

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c435d28b548330bae97c0e7a299573