### PR TITLE
Guard HUD policy/event loading

### DIFF
--- a/resources/events/cold_snap.tres
+++ b/resources/events/cold_snap.tres
@@ -1,3 +1,6 @@
-[gd_resource type="Resource" format=3 uid="uid://d1n50m6aokpw6"]
+[gd_resource type="ColdSnapEvent" load_steps=2 format=3 uid="uid://d1n50m6aokpw6"]
+[ext_resource path="res://scripts/events/ColdSnap.gd" type="Script" id="1"]
 
 [resource]
+script = ExtResource("1")
+name = "Cold Snap"

--- a/resources/events/merchant.tres
+++ b/resources/events/merchant.tres
@@ -1,3 +1,6 @@
-[gd_resource type="Resource" format=3 uid="uid://cadpr7xc40h0n"]
+[gd_resource type="TraderEvent" load_steps=2 format=3 uid="uid://cadpr7xc40h0n"]
+[ext_resource path="res://scripts/events/Trader.gd" type="Script" id="1"]
 
 [resource]
+script = ExtResource("1")
+name = "Merchant"

--- a/resources/events/merchant_return.tres
+++ b/resources/events/merchant_return.tres
@@ -1,3 +1,6 @@
-[gd_resource type="Resource" format=3 uid="uid://b8ecm46kwtudd"]
+[gd_resource type="GameEvent" load_steps=2 format=3 uid="uid://b8ecm46kwtudd"]
+[ext_resource path="res://scripts/events/Event.gd" type="Script" id="1"]
 
 [resource]
+script = ExtResource("1")
+name = "Merchant Returns"

--- a/resources/events/mysterious_rune.tres
+++ b/resources/events/mysterious_rune.tres
@@ -1,3 +1,6 @@
-[gd_resource type="Resource" format=3 uid="uid://bjwusugge7d11"]
+[gd_resource type="RuneDiscoveryEvent" load_steps=2 format=3 uid="uid://bjwusugge7d11"]
+[ext_resource path="res://scripts/events/RuneDiscovery.gd" type="Script" id="1"]
 
 [resource]
+script = ExtResource("1")
+name = "Mysterious Rune"

--- a/resources/events/rain.tres
+++ b/resources/events/rain.tres
@@ -1,3 +1,6 @@
-[gd_resource type="Resource" format=3 uid="uid://n3pbn3jrrx8n"]
+[gd_resource type="GameEvent" load_steps=2 format=3 uid="uid://n3pbn3jrrx8n"]
+[ext_resource path="res://scripts/events/Event.gd" type="Script" id="1"]
 
 [resource]
+script = ExtResource("1")
+name = "Rain"

--- a/resources/events/rune_power.tres
+++ b/resources/events/rune_power.tres
@@ -1,3 +1,6 @@
-[gd_resource type="Resource" format=3 uid="uid://c0tr0u05ppxjf"]
+[gd_resource type="GameEvent" load_steps=2 format=3 uid="uid://c0tr0u05ppxjf"]
+[ext_resource path="res://scripts/events/Event.gd" type="Script" id="1"]
 
 [resource]
+script = ExtResource("1")
+name = "Rune Power"

--- a/resources/events/sauna_diplomacy.tres
+++ b/resources/events/sauna_diplomacy.tres
@@ -1,3 +1,6 @@
-[gd_resource type="Resource" format=3 uid="uid://ikvybqhnn5o5"]
+[gd_resource type="GameEvent" load_steps=2 format=3 uid="uid://ikvybqhnn5o5"]
+[ext_resource path="res://scripts/events/Event.gd" type="Script" id="1"]
 
 [resource]
+script = ExtResource("1")
+name = "Sauna Diplomacy"

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -111,15 +111,17 @@ func _populate_policies() -> void:
     policy_selector.clear()
     for file in DirAccess.get_files_at("res://resources/policies"):
         if file.get_extension() == "tres":
-            var p: Policy = load("res://resources/policies/%s" % file)
-            policy_selector.add_item(p.name)
-            _policies.append(p)
+            var res = load("res://resources/policies/%s" % file)
+            if res is Policy and res.name:
+                policy_selector.add_item(res.name)
+                _policies.append(res)
 
 func _populate_events() -> void:
     _events.clear()
     event_selector.clear()
     for file in DirAccess.get_files_at("res://resources/events"):
         if file.get_extension() == "tres":
-            var e: GameEventBase = load("res://resources/events/%s" % file)
-            event_selector.add_item(e.name)
-            _events.append(e)
+            var res = load("res://resources/events/%s" % file)
+            if res is GameEventBase and res.name:
+                event_selector.add_item(res.name)
+                _events.append(res)


### PR DESCRIPTION
## Summary
- Skip invalid policy and event resources when populating HUD menus
- Define event resource files with proper scripts and user-facing names

## Testing
- ⚠️ `godot --headless --path . -s tests/test_runner.gd` (fails: Identifier "Resources" not declared)
- ⚠️ `godot --headless -s hud_test.gd` (fails: Identifier "Resources" not declared)


------
https://chatgpt.com/codex/tasks/task_e_68c43857cd8c83308c2344cdcf941add