### PR TITLE
feat: expand world radius

### DIFF
--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -12,6 +12,7 @@ current = true
 
 [node name="HexMap" type="Node2D" parent="."]
 script = ExtResource("4")
+radius = 6
 
 [node name="TileMap" type="TileMap" parent="HexMap"]
 tile_set = ExtResource("2")

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -18,6 +18,8 @@ func _ready() -> void:
     assert(terrain is TileMapLayer, "Terrain layer must be TileMapLayer")
     assert(buildings is TileMapLayer, "Buildings layer must be TileMapLayer")
     assert(fog is TileMapLayer, "Fog layer must be TileMapLayer")
+    if radius <= 0:
+        push_warning("HexMap radius is 0")
     _ensure_singletons()
     if GameState.tiles.is_empty():
         _generate_tiles()


### PR DESCRIPTION
## Summary
- increase HexMap radius in the world scene to generate more hex tiles
- warn when HexMap radius is zero

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found: godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68c43b9e7930833086f2ab6b8229b646