### PR TITLE
feat: render terrain sprites

### DIFF
--- a/scenes/world/HexTile.tscn
+++ b/scenes/world/HexTile.tscn
@@ -4,3 +4,5 @@
 
 [node name="HexTile" type="Node2D"]
 script = ExtResource("1")
+
+[node name="Sprite" type="Sprite2D" parent="."]

--- a/scripts/world/HexTile.gd
+++ b/scripts/world/HexTile.gd
@@ -4,3 +4,18 @@ extends Node2D
 @export var r: int = 0
 @export var terrain: String = "plain"
 @export var resource: String = ""
+
+@onready var sprite: Sprite2D = $Sprite
+
+const TERRAIN_TEXTURES := {
+    "water": preload("res://assets/tiles/lake.svg"),
+    "mountain": preload("res://assets/tiles/hill.svg"),
+    "grass": preload("res://assets/tiles/forest.svg"),
+}
+
+func _ready() -> void:
+    update_sprite()
+
+func update_sprite() -> void:
+    var tex: Texture2D = TERRAIN_TEXTURES.get(terrain, TERRAIN_TEXTURES["grass"])
+    sprite.texture = tex

--- a/scripts/world/MapGenerator.gd
+++ b/scripts/world/MapGenerator.gd
@@ -40,6 +40,7 @@ func _generate_and_store() -> void:
             hex.r = r
             hex.terrain = terrain_type
             hex.resource = resource_type
+            hex.update_sprite()
             hex.position = HexUtils.axial_to_world(q, r, hex_radius)
             add_child(hex)
             var coord := Vector2i(q, r)
@@ -58,5 +59,6 @@ func _draw_from_saved() -> void:
         hex.r = coord.y
         hex.terrain = data.get("terrain", "water")
         hex.resource = data.get("resource", "")
+        hex.update_sprite()
         hex.position = HexUtils.axial_to_world(coord.x, coord.y, hex_radius)
         add_child(hex)


### PR DESCRIPTION
## Summary
- Add Sprite2D child to HexTile scene
- Load terrain textures and update sprite based on terrain
- Ensure MapGenerator configures sprite so generated tiles are visible

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c43c7d1b2883308cacfc882b67662a