### PR TITLE
Add project font references without bundling binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ Thumbs.db
 # Logs & temp
 logs/
 *.tmp
+
+# Font files (not stored in repository)
+assets/fonts/*.ttf
+assets/fonts/*.otf

--- a/assets/fonts/README.md
+++ b/assets/fonts/README.md
@@ -1,0 +1,10 @@
+This directory should contain font files used by the project.
+
+To keep the repository lightweight and avoid storing binary assets,
+acquire the following fonts separately and place them in this folder:
+
+- `OpenSans-Regular.ttf`
+- `PressStart2P-Regular.ttf`
+
+Fonts can be downloaded from [Google Fonts](https://fonts.google.com/)
+or other reliable sources.

--- a/resources/Theme.tres
+++ b/resources/Theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=2 format=3 uid="uid://bwnrt26jf02ih"]
+[gd_resource type="Theme" load_steps=4 format=3 uid="uid://bwnrt26jf02ih"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 content_margin_left = 8.0
@@ -11,9 +11,17 @@ corner_radius_top_right = 12
 corner_radius_bottom_right = 12
 corner_radius_bottom_left = 12
 
+[sub_resource type="FontFile" id="2"]
+font_path = "res://assets/fonts/OpenSans-Regular.ttf"
+
+[sub_resource type="FontFile" id="3"]
+font_path = "res://assets/fonts/PressStart2P-Regular.ttf"
+
 [resource]
 Button/styles/disabled = SubResource("1")
 Button/styles/focus = SubResource("1")
 Button/styles/hover = SubResource("1")
 Button/styles/normal = SubResource("1")
 Button/styles/pressed = SubResource("1")
+default_font = SubResource("2")
+fonts/PressStart2P = SubResource("3")


### PR DESCRIPTION
## Summary
- configure Theme.tres to use OpenSans as default font and expose PressStart2P
- ignore font binaries and document how to obtain them externally

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c43d6d8df08330a78a43fce038dd72