### PR TITLE
Refactor HexMap to remove TileMap parent

### DIFF
--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -14,15 +14,17 @@ current = true
 script = ExtResource("4")
 radius = 6
 
-[node name="TileMap" type="TileMap" parent="HexMap"]
+[node name="Terrain" type="TileMapLayer" parent="HexMap"]
 tile_set = ExtResource("2")
 cell_tile_size = Vector2i(96, 84)
 
-[node name="Terrain" type="TileMapLayer" parent="HexMap/TileMap"]
+[node name="Buildings" type="TileMapLayer" parent="HexMap"]
+tile_set = ExtResource("2")
+cell_tile_size = Vector2i(96, 84)
 
-[node name="Buildings" type="TileMapLayer" parent="HexMap/TileMap"]
-
-[node name="Fog" type="TileMapLayer" parent="HexMap/TileMap"]
+[node name="Fog" type="TileMapLayer" parent="HexMap"]
+tile_set = ExtResource("2")
+cell_tile_size = Vector2i(96, 84)
 modulate = Color(1, 1, 1, 0.55)
 
 [node name="Units" type="Node2D" parent="."]

--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -4,11 +4,11 @@ class_name FogMap
 ## Name used to identify the fog source within the TileSet.
 const FOG_SOURCE_NAME := "fog"
 
-var tile_map: TileMap
+var tile_map: TileMapLayer
 var fog_layer: TileMapLayer
 var source_id: int = -1
 
-func _init(p_tile_map: TileMap, p_fog_layer: TileMapLayer) -> void:
+func _init(p_tile_map: TileMapLayer, p_fog_layer: TileMapLayer) -> void:
     tile_map = p_tile_map
     fog_layer = p_fog_layer
     var tset: TileSet = tile_map.tile_set

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -6,15 +6,15 @@ const TILE_SIZE := Vector2i(96, 84)
 @export var radius: int = 0
 @export var terrain_weights: Dictionary = {}
 
-@onready var grid: TileMap = $TileMap
-@onready var terrain: TileMapLayer = $TileMap/Terrain
-@onready var buildings: TileMapLayer = $TileMap/Buildings
-@onready var fog: TileMapLayer = $TileMap/Fog
+@onready var grid: TileMapLayer = $Terrain
+@onready var terrain: TileMapLayer = $Terrain
+@onready var buildings: TileMapLayer = $Buildings
+@onready var fog: TileMapLayer = $Fog
 
 signal tile_clicked(cell: Vector2i)
 
 func _ready() -> void:
-    assert(grid is TileMap, "TileMap node missing or wrong type")
+    assert(grid is TileMapLayer, "TileMapLayer node missing or wrong type")
     assert(terrain is TileMapLayer, "Terrain layer must be TileMapLayer")
     assert(buildings is TileMapLayer, "Buildings layer must be TileMapLayer")
     assert(fog is TileMapLayer, "Fog layer must be TileMapLayer")

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -3,7 +3,7 @@ extends Node2D
 signal tile_clicked(qr: Vector2i)
 
 @onready var cam: Camera2D = $Camera2D
-@onready var grid: TileMap = $HexMap/TileMap
+@onready var grid: TileMapLayer = $HexMap/Terrain
 @onready var hex_map: HexMap = $HexMap
 @onready var units_root: Node2D = $Units
 

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -6,26 +6,29 @@ class DummyHexMap:
     extends HexMapBase
 
     func _init():
-        grid = TileMap.new()
-        grid.name = "TileMap"
-        grid.tile_set = TileSet.new()
-        grid.tile_set.tile_size = TILE_SIZE
-        grid.tile_set.tile_shape = TileSet.TILE_SHAPE_HEXAGON
-        add_child(grid)
+        var tset := TileSet.new()
+        tset.tile_size = TILE_SIZE
+        tset.tile_shape = TileSet.TILE_SHAPE_HEXAGON
 
         var terrain_layer := TileMapLayer.new()
         terrain_layer.name = "Terrain"
-        grid.add_child(terrain_layer)
+        terrain_layer.tile_set = tset
+        terrain_layer.cell_tile_size = TILE_SIZE
+        add_child(terrain_layer)
 
         var buildings_layer := TileMapLayer.new()
         buildings_layer.name = "Buildings"
-        grid.add_child(buildings_layer)
+        buildings_layer.tile_set = tset
+        buildings_layer.cell_tile_size = TILE_SIZE
+        add_child(buildings_layer)
 
         var fog_layer := TileMapLayer.new()
         fog_layer.name = "Fog"
-        grid.add_child(fog_layer)
+        fog_layer.tile_set = tset
+        fog_layer.cell_tile_size = TILE_SIZE
+        add_child(fog_layer)
 
-        self.grid = grid
+        self.grid = terrain_layer
         self.terrain = terrain_layer
         self.buildings = buildings_layer
         self.fog = fog_layer


### PR DESCRIPTION
## Summary
- remove intermediate TileMap node from world scene
- update HexMap scripts to use layer nodes directly
- adjust tests to instantiate TileMapLayer nodes

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c43f673d748330802da29d1a5b4644