### PR TITLE
Preload event scripts for registration

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -5,6 +5,14 @@ extends Node
 
 const GameEventBase := preload("res://scripts/events/Event.gd")
 
+# Preload all event scripts so their classes are registered with the ClassDB
+# before any event resources are loaded.
+const _EVENT_SCRIPTS := [
+    preload("res://scripts/events/ColdSnap.gd"),
+    preload("res://scripts/events/Trader.gd"),
+    preload("res://scripts/events/RuneDiscovery.gd"),
+]
+
 var events: Array = []
 var current_event: GameEventBase = null
 var _ticks_until_event: int = 0


### PR DESCRIPTION
## Summary
- Preload event scripts at startup so their classes are registered before loading event resources

## Testing
- `godot_v4.2.2-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Identifier "Resources" not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68c441ca04e8833093b058429bc41ae6