### PR TITLE
Warn on invalid event resources

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -28,9 +28,14 @@ func _load_events() -> void:
     events.clear()
     for file in DirAccess.get_files_at("res://resources/events"):
         if file.get_extension() == "tres":
-            var res := load("res://resources/events/%s" % file)
-            if res is GameEventBase:
+            var res_path := "res://resources/events/%s" % file
+            var res := load(res_path)
+            if res == null:
+                push_warning("Failed to load event resource: %s" % res_path)
+            elif res is GameEventBase:
                 events.append(res)
+            else:
+                push_warning("Loaded resource is not a GameEventBase: %s" % res_path)
 
 func _schedule_next_event() -> void:
     _ticks_until_event = 30 + int(RNG.randf() * 21)


### PR DESCRIPTION
## Summary
- warn when event resource fails to load or isn't a GameEventBase

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: project expects Godot 4)*
- `/tmp/Godot_v4.2.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: parse errors in scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68c443654e2883308f0ff7b9815b6d8b