### PR TITLE
Start clock only after user input

### DIFF
--- a/autoload/GameClock.gd
+++ b/autoload/GameClock.gd
@@ -4,7 +4,7 @@ signal tick()
 
 const TICK_INTERVAL := 0.5
 var time: float = 0.0
-var running: bool = true
+var running: bool = false
 var _accumulator: float = 0.0
 var speed_multiplier: float = 1.0
 


### PR DESCRIPTION
## Summary
- Initialize GameClock in a stopped state so ticking begins only when start is called

## Testing
- `./godot4 --headless -s tests/test_runner.gd` *(fails: Identifier "Resources" not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68c443bef9b88330b3b7e4624c2d2a77