### PR TITLE
Preload event scripts and add missing event classes

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -5,12 +5,16 @@ extends Node
 
 const GameEventBase := preload("res://scripts/events/Event.gd")
 
-# List of event script paths to ensure their classes are registered with the
+# List of event scripts to ensure their classes are registered with the
 # ClassDB before any event resources are loaded.
-const _EVENT_SCRIPT_PATHS := [
-    "res://scripts/events/ColdSnap.gd",
-    "res://scripts/events/Trader.gd",
-    "res://scripts/events/RuneDiscovery.gd",
+const _EVENT_SCRIPTS := [
+    preload("res://scripts/events/ColdSnap.gd"),
+    preload("res://scripts/events/MerchantReturn.gd"),
+    preload("res://scripts/events/Rain.gd"),
+    preload("res://scripts/events/RuneDiscovery.gd"),
+    preload("res://scripts/events/RunePower.gd"),
+    preload("res://scripts/events/SaunaDiplomacy.gd"),
+    preload("res://scripts/events/Trader.gd"),
 ]
 
 var events: Array = []
@@ -20,8 +24,8 @@ var _ticks_until_event: int = 0
 const OVERLAY_SCENE := preload("res://scenes/ui/EventOverlay.tscn")
 
 func _ready() -> void:
-    for p in _EVENT_SCRIPT_PATHS:
-        load(p)
+    for _s in _EVENT_SCRIPTS:
+        pass
     _load_events()
     GameClock.tick.connect(_on_tick)
     _schedule_next_event()

--- a/resources/events/merchant_return.tres
+++ b/resources/events/merchant_return.tres
@@ -1,5 +1,5 @@
-[gd_resource type="GameEvent" load_steps=2 format=3 uid="uid://b8ecm46kwtudd"]
-[ext_resource path="res://scripts/events/Event.gd" type="Script" id="1"]
+[gd_resource type="MerchantReturnEvent" load_steps=2 format=3 uid="uid://b8ecm46kwtudd"]
+[ext_resource path="res://scripts/events/MerchantReturn.gd" type="Script" id="1"]
 
 [resource]
 script = ExtResource("1")

--- a/resources/events/rain.tres
+++ b/resources/events/rain.tres
@@ -1,5 +1,5 @@
-[gd_resource type="GameEvent" load_steps=2 format=3 uid="uid://n3pbn3jrrx8n"]
-[ext_resource path="res://scripts/events/Event.gd" type="Script" id="1"]
+[gd_resource type="RainEvent" load_steps=2 format=3 uid="uid://n3pbn3jrrx8n"]
+[ext_resource path="res://scripts/events/Rain.gd" type="Script" id="1"]
 
 [resource]
 script = ExtResource("1")

--- a/resources/events/rune_power.tres
+++ b/resources/events/rune_power.tres
@@ -1,5 +1,5 @@
-[gd_resource type="GameEvent" load_steps=2 format=3 uid="uid://c0tr0u05ppxjf"]
-[ext_resource path="res://scripts/events/Event.gd" type="Script" id="1"]
+[gd_resource type="RunePowerEvent" load_steps=2 format=3 uid="uid://c0tr0u05ppxjf"]
+[ext_resource path="res://scripts/events/RunePower.gd" type="Script" id="1"]
 
 [resource]
 script = ExtResource("1")

--- a/resources/events/sauna_diplomacy.tres
+++ b/resources/events/sauna_diplomacy.tres
@@ -1,5 +1,5 @@
-[gd_resource type="GameEvent" load_steps=2 format=3 uid="uid://ikvybqhnn5o5"]
-[ext_resource path="res://scripts/events/Event.gd" type="Script" id="1"]
+[gd_resource type="SaunaDiplomacyEvent" load_steps=2 format=3 uid="uid://ikvybqhnn5o5"]
+[ext_resource path="res://scripts/events/SaunaDiplomacy.gd" type="Script" id="1"]
 
 [resource]
 script = ExtResource("1")

--- a/scripts/events/MerchantReturn.gd
+++ b/scripts/events/MerchantReturn.gd
@@ -1,0 +1,2 @@
+extends GameEvent
+class_name MerchantReturnEvent

--- a/scripts/events/MerchantReturn.gd.uid
+++ b/scripts/events/MerchantReturn.gd.uid
@@ -1,0 +1,1 @@
+uid://ci12epzmyxjsg

--- a/scripts/events/Rain.gd
+++ b/scripts/events/Rain.gd
@@ -1,0 +1,2 @@
+extends GameEvent
+class_name RainEvent

--- a/scripts/events/Rain.gd.uid
+++ b/scripts/events/Rain.gd.uid
@@ -1,0 +1,1 @@
+uid://qyd66mxei50sm

--- a/scripts/events/RunePower.gd
+++ b/scripts/events/RunePower.gd
@@ -1,0 +1,2 @@
+extends GameEvent
+class_name RunePowerEvent

--- a/scripts/events/RunePower.gd.uid
+++ b/scripts/events/RunePower.gd.uid
@@ -1,0 +1,1 @@
+uid://1ulmv6qpuoc2i

--- a/scripts/events/SaunaDiplomacy.gd
+++ b/scripts/events/SaunaDiplomacy.gd
@@ -1,0 +1,2 @@
+extends GameEvent
+class_name SaunaDiplomacyEvent

--- a/scripts/events/SaunaDiplomacy.gd.uid
+++ b/scripts/events/SaunaDiplomacy.gd.uid
@@ -1,0 +1,1 @@
+uid://uhyyyw97gdzpm


### PR DESCRIPTION
## Summary
- preload every event script so their classes are registered before loading resources
- add stub scripts for Merchant Return, Rain, Rune Power, and Sauna Diplomacy events
- update event resources to reference the new classes

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: godot4 command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c445e6054483309a80c8cefe38760d