### PR TITLE
Preload Policy base class in HUD

### DIFF
--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -1,5 +1,8 @@
 extends CanvasLayer
 
+const PolicyBase := preload("res://scripts/policies/Policy.gd")
+const GameEventBase = preload("res://scripts/events/Event.gd")
+
 signal start_pressed
 signal pause_pressed
 signal build_pressed
@@ -22,8 +25,6 @@ signal building_selected
 var _policies: Array[Policy] = []
 var _events: Array[GameEventBase] = []
 var _buildings_info: Array[Building] = []
-
-const GameEventBase = preload("res://scripts/events/Event.gd")
 
 func _ready() -> void:
     start_button.pressed.connect(func(): start_pressed.emit())


### PR DESCRIPTION
## Summary
- Register the Policy class in HUD by preloading Policy.gd so policy resources load correctly

## Testing
- `gdlint scripts/ui/Hud.gd` *(fails: Definition out of order in global scope)*
- `godot4 --headless --run tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4498ff9ac8330a82329e982fa6ecf