### PR TITLE
Handle missing resources in EventManager and HUD

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -92,8 +92,13 @@ func _on_choice_selected(choice: Dictionary) -> void:
     var next_path: String = choice.get("next_event", "")
     current_event = null
     if next_path != "":
-        var next_ev: GameEventBase = load(next_path)
-        start_event(next_ev)
+        var next_res := load(next_path)
+        if next_res == null:
+            push_warning("Failed to load next event resource: %s" % next_path)
+        elif next_res is GameEventBase:
+            start_event(next_res)
+        else:
+            push_warning("Loaded next event is not a GameEventBase: %s" % next_path)
     else:
         GameClock.start()
         _schedule_next_event()

--- a/docs/resource_loading_failures.md
+++ b/docs/resource_loading_failures.md
@@ -1,0 +1,10 @@
+# Resource Loading Failures
+
+The HUD and EventManager verify that resources loaded at runtime are valid before use. When a resource fails to load or has the wrong type, a warning is logged and the resource is skipped.
+
+## Failure Cases
+
+- **Missing resource files**: If an expected `.tres` file cannot be found, a warning such as `Failed to load event resource: res://resources/events/Foo.tres` is printed.
+- **Incorrect resource type**: When a resource loads but does not inherit from the expected base class (`GameEventBase`, `PolicyBase`, or `Building`), it is ignored and a warning explains the mismatch.
+
+These warnings appear in the Godot output and help track down misconfigured or missing content without interrupting gameplay.

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -103,26 +103,39 @@ func _populate_buildings() -> void:
     building_selector.clear()
     for file in DirAccess.get_files_at("res://resources/buildings"):
         if file.get_extension() == "tres":
-            var b: Building = load("res://resources/buildings/%s" % file)
-            building_selector.add_item(b.name)
-            _buildings_info.append(b)
+            var b_res := load("res://resources/buildings/%s" % file)
+            if b_res == null:
+                push_warning("Failed to load building resource: res://resources/buildings/%s" % file)
+            elif b_res is Building and b_res.name:
+                building_selector.add_item(b_res.name)
+                _buildings_info.append(b_res)
+            else:
+                push_warning("Loaded resource is not a Building: res://resources/buildings/%s" % file)
 
 func _populate_policies() -> void:
     _policies.clear()
     policy_selector.clear()
     for file in DirAccess.get_files_at("res://resources/policies"):
         if file.get_extension() == "tres":
-            var res = load("res://resources/policies/%s" % file)
-            if res is Policy and res.name:
+            var res := load("res://resources/policies/%s" % file)
+            if res == null:
+                push_warning("Failed to load policy resource: res://resources/policies/%s" % file)
+            elif res is PolicyBase and res.name:
                 policy_selector.add_item(res.name)
                 _policies.append(res)
+            else:
+                push_warning("Loaded resource is not a Policy: res://resources/policies/%s" % file)
 
 func _populate_events() -> void:
     _events.clear()
     event_selector.clear()
     for file in DirAccess.get_files_at("res://resources/events"):
         if file.get_extension() == "tres":
-            var res = load("res://resources/events/%s" % file)
-            if res is GameEventBase and res.name:
+            var res := load("res://resources/events/%s" % file)
+            if res == null:
+                push_warning("Failed to load event resource: res://resources/events/%s" % file)
+            elif res is GameEventBase and res.name:
                 event_selector.add_item(res.name)
                 _events.append(res)
+            else:
+                push_warning("Loaded resource is not a GameEventBase: res://resources/events/%s" % file)


### PR DESCRIPTION
## Summary
- Guard runtime load() calls in EventManager and HUD with null and type checks
- Warn when resource files are missing or of unexpected type
- Document resource-loading failure scenarios for easier troubleshooting

## Testing
- `./Godot_v4.4.1-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Identifier "Resources" not declared and missing font assets)*

------
https://chatgpt.com/codex/tasks/task_e_68c44e4f7d048330bf9780f95bc5e36d