### PR TITLE
Ensure event scripts register classes before loading events

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -26,8 +26,8 @@ var _ticks_until_event: int = 0
 const OVERLAY_SCENE := preload("res://scenes/ui/EventOverlay.tscn")
 
 func _ready() -> void:
-    for _s in _EVENT_SCRIPTS:
-        pass
+    for script in _EVENT_SCRIPTS:
+        script.new()  # ensures class_name is registered
     _load_events()
     GameClock.tick.connect(_on_tick)
     _schedule_next_event()


### PR DESCRIPTION
## Summary
- Instantiate event scripts in EventManager to register classes before loading events

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c45035e7d08330ae29f2540be3ef59