### PR TITLE
Improve event loading diagnostics

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -37,9 +37,9 @@ func _load_events() -> void:
     for file in DirAccess.get_files_at("res://resources/events"):
         if file.get_extension() == "tres":
             var res_path := "res://resources/events/%s" % file
-            var res: Resource = ResourceLoader.load(res_path)
-            if res == null:
-                var err: int = ERR_PARSE_ERROR if ResourceLoader.exists(res_path) else ERR_FILE_NOT_FOUND
+            var err := OK
+            var res: Resource = ResourceLoader.load(res_path, "", ResourceLoader.CACHE_MODE_REUSE, false, err)
+            if err != OK or res == null:
                 push_warning("Failed to load event resource: %s (error %s)" % [res_path, err])
             elif res is GameEventBase:
                 events.append(res)


### PR DESCRIPTION
## Summary
- add error code reporting when loading event resources

## Testing
- `gdformat --check scripts/events/ColdSnap.gd`
- `./godot --headless --script tests/test_events.gd` *(fails: Could not resolve script "res://scripts/events/Event.gd" and missing font resources)*

------
https://chatgpt.com/codex/tasks/task_e_68c4538d19a0833089344127f465268e