### PR TITLE
Explicitly type building source ID

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -65,7 +65,7 @@ func _draw_from_saved(saved: Dictionary) -> void:
         var b = data.get("building", null)
         if b != null and b != "":
             var building_name := String(b)
-            var source_id := BUILDING_SOURCE_IDS.get(building_name, DEFAULT_BUILDING_SOURCE_ID)
+            var source_id: int = BUILDING_SOURCE_IDS.get(building_name, DEFAULT_BUILDING_SOURCE_ID)
             buildings.set_cell(1, coord, source_id)
         if data.get("explored", false):
             fog.erase_cell(2, coord)


### PR DESCRIPTION
## Summary
- use explicit `int` type for building source ID in `_draw_from_saved`

## Testing
- `pytest`
- `godot4 --headless --check-only` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c45972cbbc8330a68a3576f7acb37e