### PR TITLE
Handle missing buildings with empty string

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -52,7 +52,7 @@ func save() -> void:
     var tile_data: Dictionary = {}
     for c in tiles.keys():
         var t: Dictionary = tiles[c]
-        var b = t.get("building", null)
+        var b = t.get("building", "")
         if b is BuildingLib:
             t = t.duplicate()
             t["building"] = b.resource_path.get_file().get_basename()

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -62,8 +62,8 @@ func _draw_from_saved(saved: Dictionary) -> void:
     for coord in saved.keys():
         var data: Dictionary = saved[coord]
         _paint_terrain(coord, data.get("terrain", "plain"))
-        var b = data.get("building", null)
-        if b != null and b != "":
+        var b: String = data.get("building", "")
+        if b != "":
             var building_name := String(b)
             var source_id: int = BUILDING_SOURCE_IDS.get(building_name, DEFAULT_BUILDING_SOURCE_ID)
             buildings.set_cell(1, coord, source_id)
@@ -95,7 +95,7 @@ func _generate_tiles() -> void:
         GameState.tiles[coord] = {
             "terrain": terrain_type,
             "owner": "none",
-            "building": null,
+            "building": "",
             "explored": false,
         }
         fog.set_cell(2, coord, 0)

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -68,7 +68,7 @@ func test_generate_tiles(res) -> void:
 func test_ready_uses_saved_tiles(res) -> void:
     _reset_tiles()
     var gs = Engine.get_main_loop().root.get_node("GameState")
-    gs.tiles[Vector2i(0,0)] = {"terrain": "forest", "owner": "none", "building": null, "explored": false}
+    gs.tiles[Vector2i(0,0)] = {"terrain": "forest", "owner": "none", "building": "", "explored": false}
     var map = DummyHexMap.new()
     map._ready()
     if gs.tiles.size() != 1 or not gs.tiles.has(Vector2i(0,0)):

--- a/tests/test_raider_spawn_performance.gd
+++ b/tests/test_raider_spawn_performance.gd
@@ -6,7 +6,7 @@ func _setup_tiles(tile_count: int, hostile_count: int) -> void:
     gs.hostile_tiles.clear()
     for i in range(tile_count):
         var coord := Vector2i(i, 0)
-        gs.tiles[coord] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
+        gs.tiles[coord] = {"terrain": "forest", "owner": "none", "building": "", "explored": true}
     for i in range(hostile_count):
         var coord := Vector2i(i * 10, 0)
         gs.set_hostile(coord, true)

--- a/tests/test_raiders.gd
+++ b/tests/test_raiders.gd
@@ -5,11 +5,11 @@ func _setup_world():
     var gs = tree.root.get_node("GameState")
     gs.units.clear()
     gs.tiles.clear()
-    gs.tiles[Vector2i(0,0)] = {"terrain": "forest", "owner": "player", "building": null, "explored": true}
-    gs.tiles[Vector2i(1,0)] = {"terrain": "lake", "owner": "none", "building": null, "explored": true}
-    gs.tiles[Vector2i(1,-1)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
-    gs.tiles[Vector2i(2,0)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
-    gs.tiles[Vector2i(2,-1)] = {"terrain": "forest", "owner": "none", "building": null, "explored": true}
+    gs.tiles[Vector2i(0,0)] = {"terrain": "forest", "owner": "player", "building": "", "explored": true}
+    gs.tiles[Vector2i(1,0)] = {"terrain": "lake", "owner": "none", "building": "", "explored": true}
+    gs.tiles[Vector2i(1,-1)] = {"terrain": "forest", "owner": "none", "building": "", "explored": true}
+    gs.tiles[Vector2i(2,0)] = {"terrain": "forest", "owner": "none", "building": "", "explored": true}
+    gs.tiles[Vector2i(2,-1)] = {"terrain": "forest", "owner": "none", "building": "", "explored": true}
     gs.set_hostile(Vector2i(2,0), true)
     var world_scene: PackedScene = load("res://scenes/world/World.tscn")
     var world = world_scene.instantiate()


### PR DESCRIPTION
## Summary
- Treat saved tile buildings as strings and skip drawing when empty
- Initialize tiles and test fixtures with empty string for missing buildings
- Save game state using empty string default for building field

## Testing
- `./godot/Godot_v4.2.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: Identifier "Resources" not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68c45a12df608330acadbc262198e2b7