### PR TITLE
type: specify building source ids dictionary

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -3,7 +3,7 @@ class_name HexMap
 
 const TILE_SIZE := Vector2i(96, 84)
 
-const BUILDING_SOURCE_IDS := {
+const BUILDING_SOURCE_IDS: Dictionary[String, int] = {
     "town": 4,
     "ruins": 5,
 }
@@ -64,7 +64,7 @@ func _draw_from_saved(saved: Dictionary) -> void:
         _paint_terrain(coord, data.get("terrain", "plain"))
         var b: String = data.get("building", "")
         if b != "":
-            var building_name := String(b)
+            var building_name: String = String(b)
             var source_id: int = BUILDING_SOURCE_IDS.get(building_name, DEFAULT_BUILDING_SOURCE_ID)
             buildings.set_cell(1, coord, source_id)
         if data.get("explored", false):


### PR DESCRIPTION
## Summary
- type BUILDING_SOURCE_IDS dictionary to expect String keys and int values
- ensure lookup variables use String key and int result types

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c45b9bb5a48330ad0f3293a16b8b32