### PR TITLE
Type existing tileset source

### DIFF
--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -34,7 +34,7 @@ func _generate_fog_texture(size: Vector2i) -> Texture2D:
 func _get_or_create_fog_source(tset: TileSet) -> int:
     var size: Vector2i = tset.tile_size
     for id in tset.get_source_id_list():
-        var existing := tset.get_source(id)
+        var existing: TileSetSource = tset.get_source(id)
         if existing is TileSetAtlasSource and existing.resource_name == FOG_SOURCE_NAME:
             return id
     var src := TileSetAtlasSource.new()


### PR DESCRIPTION
## Summary
- typecast existing TileSet source when retrieving fog TileSet source

## Testing
- `godot3 --headless --path . --script tests/test_runner.gd` *(fails: Can't open project... config_version 5 from a more recent version)*

------
https://chatgpt.com/codex/tasks/task_e_68c45c4cc3f883309fb569481b423db0