### PR TITLE
Type BUILDING_SOURCE_IDS dictionary

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -3,7 +3,7 @@ class_name HexMap
 
 const TILE_SIZE := Vector2i(96, 84)
 
-const BUILDING_SOURCE_IDS: Dictionary[String, int] = {
+const BUILDING_SOURCE_IDS: Dictionary = {
     "town": 4,
     "ruins": 5,
 }


### PR DESCRIPTION
## Summary
- type BUILDING_SOURCE_IDS as Dictionary in HexMap

## Testing
- `godot3-server -s tests/test_runner.gd` *(fails: config_version 5 is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c45d0796c08330b6e791b5be0cded3