### PR TITLE
Specify float type for noise_val in map generator

### DIFF
--- a/scripts/world/MapGenerator.gd
+++ b/scripts/world/MapGenerator.gd
@@ -24,7 +24,7 @@ func _generate_and_store() -> void:
     for r in map_height:
         for q in map_width:
             var hex: Node2D = hex_tile_scene.instantiate() as Node2D
-            var noise_val := noise.get_noise_2d(float(q), float(r))
+            var noise_val: float = noise.get_noise_2d(float(q), float(r))
             var terrain_type := "water"
             if noise_val > 0.4:
                 terrain_type = "mountain"


### PR DESCRIPTION
## Summary
- Ensure noise_val is explicitly typed as float in map generation so subsequent comparisons operate on floats

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c46966db208330b31ca51a9b696d10