### PR TITLE
Explicitly cast building source ID in HexMap

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -65,7 +65,7 @@ func _draw_from_saved(saved: Dictionary) -> void:
         var b: String = data.get("building", "")
         if b != "":
             var building_name: String = String(b)
-            var source_id: int = BUILDING_SOURCE_IDS.get(building_name, DEFAULT_BUILDING_SOURCE_ID)
+            var source_id: int = int(BUILDING_SOURCE_IDS.get(building_name, DEFAULT_BUILDING_SOURCE_ID))
             buildings.set_cell(1, coord, source_id)
         if data.get("explored", false):
             fog.erase_cell(2, coord)


### PR DESCRIPTION
## Summary
- explicitly cast saved building source ID to `int` when drawing saved map data

## Testing
- `godot4 --headless --quit` *(fails: missing project resources and scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68c4699646b08330b8c02e7ac3b87e2b