### PR TITLE
Specify integer timing variables in performance tests

### DIFF
--- a/tests/test_bfs_performance.gd
+++ b/tests/test_bfs_performance.gd
@@ -34,15 +34,15 @@ func test_bfs_performance(res) -> void:
     var goal := Vector2i(40, 0)
     var passable := func(cell: Vector2i) -> bool:
         return true
-    var queue_time := 0
-    var array_time := 0
+    var queue_time: int = 0
+    var array_time: int = 0
     var iterations := 3
     for i in range(iterations):
-        var t0 := Time.get_ticks_usec()
+        var t0: int = Time.get_ticks_usec()
         Pathing.bfs_path(start, goal, passable)
         queue_time += Time.get_ticks_usec() - t0
     for i in range(iterations):
-        var t1 := Time.get_ticks_usec()
+        var t1: int = Time.get_ticks_usec()
         _naive_bfs(start, goal, passable)
         array_time += Time.get_ticks_usec() - t1
     if queue_time * 5 >= array_time * 6:

--- a/tests/test_raider_spawn_performance.gd
+++ b/tests/test_raider_spawn_performance.gd
@@ -25,14 +25,14 @@ func _optimized_spawn_loop() -> void:
 func test_raider_spawn_performance(res) -> void:
     _setup_tiles(10000, 10)
     var iterations := 50
-    var t0 := Time.get_ticks_usec()
+    var t0: int = Time.get_ticks_usec()
     for i in range(iterations):
         _naive_spawn_loop()
-    var naive_time := Time.get_ticks_usec() - t0
-    var t1 := Time.get_ticks_usec()
+    var naive_time: int = Time.get_ticks_usec() - t0
+    var t1: int = Time.get_ticks_usec()
     for i in range(iterations):
         _optimized_spawn_loop()
-    var opt_time := Time.get_ticks_usec() - t1
+    var opt_time: int = Time.get_ticks_usec() - t1
     var gs = Engine.get_main_loop().root.get_node("GameState")
     gs.tiles.clear()
     gs.hostile_tiles.clear()


### PR DESCRIPTION
## Summary
- declare timing variables as `int` in BFS performance test
- declare timing variables as `int` in raider spawn performance test

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `godot3-server --path . -s tests/test_runner.gd` *(fails: Can't open project, config_version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68c46d8c8f94833083c47531aa3036e7