### PR TITLE
Handle missing parent in BattleManager

### DIFF
--- a/scripts/battle/BattleManager.gd
+++ b/scripts/battle/BattleManager.gd
@@ -8,9 +8,11 @@ var units_root: Node2D = null
 
 func _ready() -> void:
     world = get_parent()
-    if world:
-        hex_map = world.get_node("HexMap") as HexMap
-        units_root = world.get_node("Units")
+    if world == null:
+        push_error("BattleManager requires a parent node.")
+        return
+    hex_map = world.get_node("HexMap") as HexMap
+    units_root = world.get_node("Units")
 
 func process_tick() -> void:
     if GameState.units.is_empty():

--- a/tests/test_battle.gd
+++ b/tests/test_battle.gd
@@ -4,6 +4,12 @@ func _remove_save(gs) -> void:
     if FileAccess.file_exists(gs.SAVE_PATH):
         DirAccess.remove_absolute(gs.SAVE_PATH)
 
+func test_battle_manager_no_parent(res) -> void:
+    var bm := BattleManager.new()
+    bm._ready()
+    if bm.world != null or bm.hex_map != null or bm.units_root != null:
+        res.fail("BattleManager should not initialize without parent node")
+
 func test_battle_player_win(res) -> void:
     var tree = Engine.get_main_loop()
     var gs = tree.root.get_node("GameState")


### PR DESCRIPTION
## Summary
- Guard BattleManager against missing parent nodes with an early return and error
- Add unit test covering BattleManager initialization without a parent

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project, config_version (5) incompatible with engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c46e5cb7b083309d5bb15a63b1a46b