### PR TITLE
Add UnitNode type and safe lookup

### DIFF
--- a/scripts/battle/BattleManager.gd
+++ b/scripts/battle/BattleManager.gd
@@ -40,10 +40,12 @@ func process_tick() -> void:
     if changed:
         GameState.save()
 
-func _find_unit_node(uid: String) -> Node:
+## Returns the UnitNode child with the matching `id` from `units_root`.
+## Only children of type UnitNode are considered.
+func _find_unit_node(uid: String) -> UnitNode:
     if units_root == null:
         return null
     for child in units_root.get_children():
-        if child.id == uid:
+        if child is UnitNode and child.id == uid:
             return child
     return null

--- a/scripts/units/Unit.gd
+++ b/scripts/units/Unit.gd
@@ -1,4 +1,5 @@
 extends Node2D
+class_name UnitNode
 
 const UnitDataBase = preload("res://scripts/units/UnitData.gd")
 


### PR DESCRIPTION
## Summary
- register UnitNode class for unit scripts
- safely look up units only among UnitNode children
- document `_find_unit_node` expectations

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c46f894e648330ac97a61a759f3490