### PR TITLE
Persist newly generated tiles

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -73,6 +73,7 @@ func save() -> void:
         "units": unit_data,
         "tutorial_done": tutorial_done,
     }
+    DirAccess.make_dir_recursive_absolute(SAVE_PATH.get_base_dir())
     var file := FileAccess.open(SAVE_PATH, FileAccess.WRITE)
     if file:
         file.store_string(JSON.stringify(data))

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -106,6 +106,7 @@ func _generate_tiles() -> void:
             "explored": false,
         }
         fog.set_cell(2, coord, 0)
+    GameState.save()
 
 func _choose_terrain() -> String:
     var total := 0.0

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -156,3 +156,21 @@ func test_seed_generates_consistent_map(res) -> void:
     if JSON.stringify(first) != JSON.stringify(second):
         res.fail("maps differ with same seed")
 
+func test_tiles_are_saved_after_generation(res) -> void:
+    _reset_tiles()
+    var tree = Engine.get_main_loop()
+    var gs = tree.root.get_node("GameState")
+    _remove_save(gs)
+    var map = DummyHexMap.new()
+    map.radius = 1
+    map.terrain_weights = {"forest": 1.0}
+    map._generate_tiles()
+    if not FileAccess.file_exists(gs.SAVE_PATH):
+        res.fail("save file not created after tile generation")
+        return
+    gs.tiles.clear()
+    gs.load()
+    if gs.tiles.is_empty():
+        res.fail("tiles not persisted after generation")
+    _remove_save(gs)
+


### PR DESCRIPTION
## Summary
- Save tiles after generation so new maps persist
- Ensure GameState.save creates save path before writing
- Test: verify generating tiles creates a save file and persists data

## Testing
- `godot --headless --path . -s tests/test_runner.gd` *(fails: Identifier "Resources" not declared in the current scope)*

------
https://chatgpt.com/codex/tasks/task_e_68c506b7d5bc83308cab252a52afd8eb