### PR TITLE
Refactor event resource headers

### DIFF
--- a/resources/events/cold_snap.tres
+++ b/resources/events/cold_snap.tres
@@ -1,4 +1,4 @@
-[gd_resource type="ColdSnapEvent" load_steps=2 format=3 uid="uid://d1n50m6aokpw6"]
+[gd_resource type="Resource" script_class="ColdSnapEvent" load_steps=2 format=3 uid="uid://d1n50m6aokpw6"]
 [ext_resource path="res://scripts/events/ColdSnap.gd" type="Script" id="1"]
 
 [resource]

--- a/resources/events/heat_wave.tres
+++ b/resources/events/heat_wave.tres
@@ -1,4 +1,4 @@
-[gd_resource type="HeatWaveEvent" load_steps=2 format=3 uid="uid://f3a327eab47344a3a249c5afc58f4017"]
+[gd_resource type="Resource" script_class="HeatWaveEvent" load_steps=2 format=3 uid="uid://f3a327eab47344a3a249c5afc58f4017"]
 [ext_resource path="res://scripts/events/HeatWave.gd" type="Script" id="1"]
 
 [resource]

--- a/resources/events/merchant.tres
+++ b/resources/events/merchant.tres
@@ -1,4 +1,4 @@
-[gd_resource type="TraderEvent" load_steps=2 format=3 uid="uid://cadpr7xc40h0n"]
+[gd_resource type="Resource" script_class="TraderEvent" load_steps=2 format=3 uid="uid://cadpr7xc40h0n"]
 [ext_resource path="res://scripts/events/Trader.gd" type="Script" id="1"]
 
 [resource]

--- a/resources/events/merchant_return.tres
+++ b/resources/events/merchant_return.tres
@@ -1,4 +1,4 @@
-[gd_resource type="MerchantReturnEvent" load_steps=2 format=3 uid="uid://b8ecm46kwtudd"]
+[gd_resource type="Resource" script_class="MerchantReturnEvent" load_steps=2 format=3 uid="uid://b8ecm46kwtudd"]
 [ext_resource path="res://scripts/events/MerchantReturn.gd" type="Script" id="1"]
 
 [resource]

--- a/resources/events/mysterious_rune.tres
+++ b/resources/events/mysterious_rune.tres
@@ -1,4 +1,4 @@
-[gd_resource type="RuneDiscoveryEvent" load_steps=2 format=3 uid="uid://bjwusugge7d11"]
+[gd_resource type="Resource" script_class="RuneDiscoveryEvent" load_steps=2 format=3 uid="uid://bjwusugge7d11"]
 [ext_resource path="res://scripts/events/RuneDiscovery.gd" type="Script" id="1"]
 
 [resource]

--- a/resources/events/rain.tres
+++ b/resources/events/rain.tres
@@ -1,4 +1,4 @@
-[gd_resource type="RainEvent" load_steps=2 format=3 uid="uid://n3pbn3jrrx8n"]
+[gd_resource type="Resource" script_class="RainEvent" load_steps=2 format=3 uid="uid://n3pbn3jrrx8n"]
 [ext_resource path="res://scripts/events/Rain.gd" type="Script" id="1"]
 
 [resource]

--- a/resources/events/run_boom.tres
+++ b/resources/events/run_boom.tres
@@ -1,4 +1,4 @@
-[gd_resource type="RunBoomEvent" load_steps=2 format=3 uid="uid://1c2dd5201e464e57959590be7cddb02f"]
+[gd_resource type="Resource" script_class="RunBoomEvent" load_steps=2 format=3 uid="uid://1c2dd5201e464e57959590be7cddb02f"]
 [ext_resource path="res://scripts/events/RunBoom.gd" type="Script" id="1"]
 
 [resource]

--- a/resources/events/rune_power.tres
+++ b/resources/events/rune_power.tres
@@ -1,4 +1,4 @@
-[gd_resource type="RunePowerEvent" load_steps=2 format=3 uid="uid://c0tr0u05ppxjf"]
+[gd_resource type="Resource" script_class="RunePowerEvent" load_steps=2 format=3 uid="uid://c0tr0u05ppxjf"]
 [ext_resource path="res://scripts/events/RunePower.gd" type="Script" id="1"]
 
 [resource]

--- a/resources/events/sauna_diplomacy.tres
+++ b/resources/events/sauna_diplomacy.tres
@@ -1,4 +1,4 @@
-[gd_resource type="SaunaDiplomacyEvent" load_steps=2 format=3 uid="uid://ikvybqhnn5o5"]
+[gd_resource type="Resource" script_class="SaunaDiplomacyEvent" load_steps=2 format=3 uid="uid://ikvybqhnn5o5"]
 [ext_resource path="res://scripts/events/SaunaDiplomacy.gd" type="Script" id="1"]
 
 [resource]


### PR DESCRIPTION
## Summary
- add `script_class` to event resource headers and standardize type as `Resource`
- keep event `.tres` files pointing to their original event scripts

## Testing
- `/tmp/godot4/Godot_v4.2.2-stable_linux.x86_64 --headless --script /tmp/load_events.gd` *(failed: missing project dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c51dec598c83308f8bce795eb3fe34