### PR TITLE
Refactor TileMap layers for Godot 4

### DIFF
--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -17,9 +17,12 @@ radius = 6
 [node name="Grid" type="TileMap" parent="HexMap"]
 tile_set = ExtResource("2")
 cell_tile_size = Vector2i(96, 84)
-layers/0/name = "Terrain"
-layers/1/name = "Buildings"
-layers/2/name = "Fog"
-layers/2/modulate = Color(1, 1, 1, 0.55)
+
+[node name="Terrain" type="TileMapLayer" parent="HexMap/Grid"]
+
+[node name="Buildings" type="TileMapLayer" parent="HexMap/Grid"]
+
+[node name="Fog" type="TileMapLayer" parent="HexMap/Grid"]
+modulate = Color(1, 1, 1, 0.55)
 
 [node name="Units" type="Node2D" parent="."]


### PR DESCRIPTION
## Summary
- Replace the single multi-layer TileMap with dedicated `Terrain`, `Buildings`, and `Fog` `TileMapLayer` nodes.
- Expose these layers in `HexMap.gd` and update tile access, assertions, and save/load logic to use the new nodes.

## Testing
- `godot3-server --headless --path . -s tests/test_runner.gd` *(fails: project.godot requires newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c51fbf7c048330985d5a37032e072b