### PR TITLE
Expose tilemap layers in World

### DIFF
--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -4,6 +4,9 @@ signal tile_clicked(qr: Vector2i)
 
 @onready var cam: Camera2D = $Camera2D
 @onready var grid: TileMap = $HexMap/Grid
+@onready var terrain_layer: TileMapLayer = $HexMap/Grid/Terrain
+@onready var buildings_layer: TileMapLayer = $HexMap/Grid/Buildings
+@onready var fog_layer: TileMapLayer = $HexMap/Grid/Fog
 @onready var hex_map: HexMap = $HexMap
 @onready var units_root: Node2D = $Units
 


### PR DESCRIPTION
## Summary
- Reference root TileMap and add variables for terrain, building, and fog layers in `World.gd`

## Testing
- `godot --headless --path . -s tests/test_runner.gd` *(fails: Identifier "Resources" not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68c52152beb48330a9ba9226fdf1faf4