### PR TITLE
Instantiate FogMap for layer-based fog control

### DIFF
--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -8,6 +8,9 @@ var tile_map: TileMapLayer
 var fog_layer: TileMapLayer
 var source_id: int = -1
 
+static var _cached_texture: Texture2D
+static var _cached_source: TileSetAtlasSource
+
 func _init(p_tile_map: TileMapLayer, p_fog_layer: TileMapLayer) -> void:
     tile_map = p_tile_map
     fog_layer = p_fog_layer
@@ -37,9 +40,13 @@ func _get_or_create_fog_source(tset: TileSet) -> int:
         var existing: TileSetSource = tset.get_source(id)
         if existing is TileSetAtlasSource and existing.resource_name == FOG_SOURCE_NAME:
             return id
-    var src := TileSetAtlasSource.new()
-    src.resource_name = FOG_SOURCE_NAME
-    src.texture = _generate_fog_texture(size)
-    src.modulate = Color(1, 1, 1, 0.55)
-    src.texture_region_size = size
+    if _cached_texture == null or _cached_source == null or _cached_source.texture_region_size != size:
+        if _cached_texture == null or (_cached_source != null and _cached_source.texture_region_size != size):
+            _cached_texture = _generate_fog_texture(size)
+        _cached_source = TileSetAtlasSource.new()
+        _cached_source.resource_name = FOG_SOURCE_NAME
+        _cached_source.texture = _cached_texture
+        _cached_source.modulate = Color(1, 1, 1, 0.55)
+        _cached_source.texture_region_size = size
+    var src := _cached_source.duplicate()
     return tset.add_source(src)

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -4,9 +4,6 @@ signal tile_clicked(qr: Vector2i)
 
 @onready var cam: Camera2D = $Camera2D
 @onready var grid: TileMap = $HexMap/Grid
-@onready var terrain_layer: TileMapLayer = $HexMap/Grid/Terrain
-@onready var buildings_layer: TileMapLayer = $HexMap/Grid/Buildings
-@onready var fog_layer: TileMapLayer = $HexMap/Grid/Fog
 @onready var hex_map: HexMap = $HexMap
 @onready var units_root: Node2D = $Units
 


### PR DESCRIPTION
## Summary
- create FogMap instances in HexMap and remove direct fog layer access
- cache fog texture/source so fog tiles reuse a single Atlas source
- clean up unused fog layer references in world script

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c52312056083308c7cd98efb6f189b