### PR TITLE
Refactor hex map test layers

### DIFF
--- a/autoload/GameState.gd
+++ b/autoload/GameState.gd
@@ -1,5 +1,9 @@
 extends Node
 
+# Ensure the global Resources class is available when running in headless
+# mode without the editor-generated class database.
+const Resources = preload("res://scripts/core/Resources.gd")
+
 const HALOT_PER_TICK := 0.2
 const MAKKARA_PER_TICK := 0.1
 const LOYLY_PER_TICK := 0.2

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -15,11 +15,22 @@ class DummyHexMap:
         tilemap.tile_set = tset
         add_child(tilemap)
 
+        var terrain_layer := TileMapLayer.new()
+        terrain_layer.name = "Terrain"
+        tilemap.add_child(terrain_layer)
+
+        var buildings_layer := TileMapLayer.new()
+        buildings_layer.name = "Buildings"
+        tilemap.add_child(buildings_layer)
+
+        var fog_layer := TileMapLayer.new()
+        fog_layer.name = "Fog"
+        tilemap.add_child(fog_layer)
+
         self.grid = tilemap
-        self.terrain = tilemap
-        self.buildings = tilemap
-        self.fog = tilemap
-        _setup_layers()
+        self.terrain_layer = terrain_layer
+        self.buildings_layer = buildings_layer
+        self.fog_layer = fog_layer
 
     func _set_tile(coord: Vector2i) -> void:
         pass
@@ -28,13 +39,7 @@ class DummyHexMap:
         pass
 
     func _setup_layers() -> void:
-        var tm: TileMap = grid
-        # Ensure the TileMap has three layers for terrain, buildings and fog.
-        while tm.get_layers_count() < 3:
-            tm.add_layer()
-        tm.set_layer_name(0, "Terrain")
-        tm.set_layer_name(1, "Buildings")
-        tm.set_layer_name(2, "Fog")
+        pass
 
     func _ready() -> void:
         _ensure_singletons()


### PR DESCRIPTION
## Summary
- use dedicated TileMapLayer nodes in hex map tests to mirror actual HexMap node structure
- load Resources singleton explicitly in GameState for headless tests

## Testing
- `godot4 --headless --path . -s tests/test_runner.gd` *(fails: Could not resolve script "res://scripts/events/Event.gd")*

------
https://chatgpt.com/codex/tasks/task_e_68c52498dcd08330952fc525d534160b