### PR TITLE
Rename MapGenerator seed variable to avoid shadowing

### DIFF
--- a/scripts/world/MapGenerator.gd
+++ b/scripts/world/MapGenerator.gd
@@ -2,7 +2,7 @@ extends Node2D
 
 @export var map_width: int = 10
 @export var map_height: int = 10
-@export var seed: int = 0
+@export var generator_seed: int = 0
 @export var hex_radius: float = 32.0
 
 var noise := FastNoiseLite.new()
@@ -10,8 +10,8 @@ var noise := FastNoiseLite.new()
 var _state: Node
 
 func _ready() -> void:
-    noise.seed = seed
-    RNG.seed_from_string(str(seed))
+    noise.seed = generator_seed
+    RNG.seed_from_string(str(generator_seed))
     _state = Engine.get_main_loop().root.get_node("GameState")
     if _state.tiles.is_empty():
         _generate_and_store()


### PR DESCRIPTION
## Summary
- rename MapGenerator's exported `seed` to `generator_seed`
- update noise and RNG initialization to use `generator_seed`

## Testing
- `godot --headless --check scripts/world/MapGenerator.gd` *(fails: command not found)*
- `sudo apt-get install -y godot4` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5272b9ae48330a4c38ab0947da91b