### PR TITLE
Display elapsed time on HUD

### DIFF
--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -65,7 +65,10 @@ func update_tile(tile_pos: Vector2i, building: Building) -> void:
     tile_info_label.text = text
 
 func update_clock(time: float) -> void:
-    clock_label.text = "Time: %.2f" % time
+    var total_seconds := int(time)
+    var minutes := total_seconds / 60
+    var seconds := total_seconds % 60
+    clock_label.text = "Time: %02d:%02d" % [minutes, seconds]
 
 func _on_policy_pressed() -> void:
     var idx := policy_selector.get_selected()

--- a/scripts/ui/Main.gd
+++ b/scripts/ui/Main.gd
@@ -39,6 +39,7 @@ func _ready() -> void:
 
 func _on_game_tick() -> void:
     hud.update_resources(GameState.res)
+    hud.update_clock(GameClock.time)
     _update_sisu_buttons()
 
 func _on_building_selected(building_name: String) -> void:


### PR DESCRIPTION
## Summary
- Update main game tick to refresh HUD clock with elapsed time
- Format HUD clock into minutes and seconds

## Testing
- ⚠️ `godot4 --headless -s tests/test_runner.gd` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5373cf42483308af711980a95bdf7