### PR TITLE
Save game after building placement

### DIFF
--- a/scripts/ui/Main.gd
+++ b/scripts/ui/Main.gd
@@ -63,6 +63,7 @@ func _on_build_pressed() -> void:
     GameState.tiles[_last_clicked] = tile
     hud.update_tile(_last_clicked, _selected_building)
     hud.update_resources(GameState.res)
+    GameState.save()
 
 func _on_tile_clicked(qr: Vector2i) -> void:
     _last_clicked = qr


### PR DESCRIPTION
## Summary
- Persist building placements by saving the game state after constructing a building

## Testing
- `./Godot_v4.4.1-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Could not resolve script "res://scripts/events/Event.gd" and related dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c5788dd2348330a22528e947986805