### PR TITLE
Fix HUD clock minute conversion

### DIFF
--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -66,7 +66,7 @@ func update_tile(tile_pos: Vector2i, building: Building) -> void:
 
 func update_clock(time: float) -> void:
     var total_seconds := int(time)
-    var minutes := total_seconds / 60
+    var minutes := int(total_seconds / 60)
     var seconds := total_seconds % 60
     clock_label.text = "Time: %02d:%02d" % [minutes, seconds]
 


### PR DESCRIPTION
## Summary
- Cast minutes to int in HUD clock update to avoid float formatting issues

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c57b430fd4833089204b98e93a8179