### PR TITLE
Refactor TileMap to built-in layers

### DIFF
--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -17,12 +17,9 @@ radius = 6
 [node name="Grid" type="TileMap" parent="HexMap"]
 tile_set = ExtResource("2")
 cell_tile_size = Vector2i(96, 84)
-
-[node name="Terrain" type="TileMapLayer" parent="HexMap/Grid"]
-
-[node name="Buildings" type="TileMapLayer" parent="HexMap/Grid"]
-
-[node name="Fog" type="TileMapLayer" parent="HexMap/Grid"]
-modulate = Color(1, 1, 1, 0.55)
+layers/0/name = "Terrain"
+layers/1/name = "Buildings"
+layers/2/name = "Fog"
+layers/2/modulate = Color(1, 1, 1, 0.55)
 
 [node name="Units" type="Node2D" parent="."]

--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -4,14 +4,14 @@ class_name FogMap
 ## Name used to identify the fog source within the TileSet.
 const FOG_SOURCE_NAME := "fog"
 
-var tile_map: TileMapLayer
-var fog_layer: TileMapLayer
+var tile_map: TileMap
+var fog_layer: int
 var source_id: int = -1
 
 static var _cached_texture: Texture2D
 static var _cached_source: TileSetAtlasSource
 
-func _init(p_tile_map: TileMapLayer, p_fog_layer: TileMapLayer) -> void:
+func _init(p_tile_map: TileMap, p_fog_layer: int) -> void:
     tile_map = p_tile_map
     fog_layer = p_fog_layer
     var tset: TileSet = tile_map.tile_set
@@ -22,10 +22,10 @@ func _init(p_tile_map: TileMapLayer, p_fog_layer: TileMapLayer) -> void:
     source_id = _get_or_create_fog_source(tset)
 
 func set_fog(coord: Vector2i) -> void:
-    fog_layer.set_cell(coord, source_id)
+    tile_map.set_cell(fog_layer, coord, source_id)
 
 func clear_fog(coord: Vector2i) -> void:
-    fog_layer.erase_cell(coord)
+    tile_map.erase_cell(fog_layer, coord)
 
 ## Generates a fog texture based on the TileSet tile size.
 func _generate_fog_texture(size: Vector2i) -> Texture2D:

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -15,10 +15,11 @@ const DEFAULT_BUILDING_SOURCE_ID := 4
 @export var terrain_weights: Dictionary[String, float] = {}
 
 @onready var grid: TileMap = $Grid
-@onready var terrain_layer: TileMapLayer = $Grid/Terrain
-@onready var buildings_layer: TileMapLayer = $Grid/Buildings
-@onready var fog_layer: TileMapLayer = $Grid/Fog
 var fog_map: FogMap
+
+const TERRAIN_LAYER := 0
+const BUILDINGS_LAYER := 1
+const FOG_LAYER := 2
 
 const CONFIG_SEED_PATH := "finsim/seed"
 var _rng := RandomNumberGenerator.new()
@@ -27,15 +28,12 @@ signal tile_clicked(cell: Vector2i)
 
 func _ready() -> void:
     assert(grid is TileMap, "TileMap node missing or wrong type")
-    assert(terrain_layer is TileMapLayer, "Terrain layer must be TileMapLayer")
-    assert(buildings_layer is TileMapLayer, "Buildings layer must be TileMapLayer")
-    assert(fog_layer is TileMapLayer, "Fog layer must be TileMapLayer")
     if radius <= 0:
         push_warning("HexMap radius is 0")
     _ensure_singletons()
     map_seed = int(ProjectSettings.get_setting(CONFIG_SEED_PATH, map_seed))
     _rng.seed = map_seed
-    fog_map = FogMap.new(terrain_layer, fog_layer)
+    fog_map = FogMap.new(grid, FOG_LAYER)
     if GameState.tiles.is_empty():
         _generate_tiles()
     else:
@@ -58,16 +56,16 @@ func reveal_area(center: Vector2i, reveal_radius: int = 2) -> void:
             GameState.tiles[cell] = t
 
 func reveal_all() -> void:
-    fog_layer.clear()
+    grid.clear_layer(FOG_LAYER)
     for coord in GameState.tiles.keys():
         var t: Dictionary = GameState.tiles[coord]
         t["explored"] = true
         GameState.tiles[coord] = t
 
 func _draw_from_saved(saved: Dictionary) -> void:
-    terrain_layer.clear()
-    buildings_layer.clear()
-    fog_layer.clear()
+    grid.clear_layer(TERRAIN_LAYER)
+    grid.clear_layer(BUILDINGS_LAYER)
+    grid.clear_layer(FOG_LAYER)
     for coord in saved.keys():
         var data: Dictionary = saved[coord]
         _paint_terrain(coord, data.get("terrain", "plain"))
@@ -75,7 +73,7 @@ func _draw_from_saved(saved: Dictionary) -> void:
         if b != "":
             var building_name: String = b
             var source_id: int = BUILDING_SOURCE_IDS.get(building_name, DEFAULT_BUILDING_SOURCE_ID)
-            buildings_layer.set_cell(coord, source_id)
+            grid.set_cell(BUILDINGS_LAYER, coord, source_id)
         if data.get("explored", false):
             fog_map.clear_fog(coord)
         else:
@@ -94,7 +92,7 @@ func _paint_terrain(coord: Vector2i, terrain_type: String) -> void:
             source_id = 3
         _:
             source_id = 0
-    terrain_layer.set_cell(coord, source_id)
+    grid.set_cell(TERRAIN_LAYER, coord, source_id)
 
 func _generate_tiles() -> void:
     _rng.seed = map_seed

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -13,24 +13,15 @@ class DummyHexMap:
         var tilemap := TileMap.new()
         tilemap.name = "Grid"
         tilemap.tile_set = tset
+        tilemap.set_layer_name(0, "Terrain")
+        tilemap.add_layer(1)
+        tilemap.set_layer_name(1, "Buildings")
+        tilemap.add_layer(2)
+        tilemap.set_layer_name(2, "Fog")
+        tilemap.set_layer_modulate(2, Color(1, 1, 1, 0.55))
         add_child(tilemap)
 
-        var terrain_layer := TileMapLayer.new()
-        terrain_layer.name = "Terrain"
-        tilemap.add_child(terrain_layer)
-
-        var buildings_layer := TileMapLayer.new()
-        buildings_layer.name = "Buildings"
-        tilemap.add_child(buildings_layer)
-
-        var fog_layer := TileMapLayer.new()
-        fog_layer.name = "Fog"
-        tilemap.add_child(fog_layer)
-
         self.grid = tilemap
-        self.terrain_layer = terrain_layer
-        self.buildings_layer = buildings_layer
-        self.fog_layer = fog_layer
 
     func _set_tile(coord: Vector2i) -> void:
         pass


### PR DESCRIPTION
## Summary
- migrate world grid to TileMap's built-in layer system
- update HexMap and FogMap for new layer API
- adjust hex map tests to use TileMap layers

## Testing
- `/tmp/Godot_v4.2.1-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Could not resolve script "res://scripts/events/Event.gd" and related parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c57c8449b48330b8ec43f8b1dcf905