### PR TITLE
Fix minute calculation in HUD clock

### DIFF
--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -66,7 +66,7 @@ func update_tile(tile_pos: Vector2i, building: Building) -> void:
 
 func update_clock(time: float) -> void:
     var total_seconds := int(time)
-    var minutes := int(total_seconds / 60)
+    var minutes := int(time / 60.0)
     var seconds := total_seconds % 60
     clock_label.text = "Time: %02d:%02d" % [minutes, seconds]
 


### PR DESCRIPTION
## Summary
- use float division when calculating minutes in HUD clock

## Testing
- `godot3-server --path . -s tests/test_runner.gd` *(fails: Can't open project, config_version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68c57e271b74833096abdb405ee39a95