### PR TITLE
Add debug map reveal and log in world ready

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -38,6 +38,7 @@ func _ready() -> void:
         _generate_tiles()
     else:
         _draw_from_saved(GameState.tiles)
+    reveal_all()
 
 func _unhandled_input(event: InputEvent) -> void:
     if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -17,6 +17,8 @@ var raider_manager: RaiderManager
 func _ready() -> void:
     cam.position = grid.map_to_local(Vector2i(0, 0))
     hex_map.reveal_area(Vector2i(0, 0), 2)
+    print("World._ready: reveal_area executed")
+    hex_map.reveal_all()
     raider_manager = RaiderManager.new()
     add_child(raider_manager)
     raider_manager.setup(hex_map, units_root, unit_scene)


### PR DESCRIPTION
## Summary
- log when `World._ready` runs reveal_area
- reveal entire map after generation for easier debugging

## Testing
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: missing resources and parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c581c8cb1c8330877c982253e30df2