### PR TITLE
Add TileSet presence check in World setup

### DIFF
--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -15,6 +15,7 @@ const UnitDataBase = preload("res://scripts/units/UnitData.gd")
 var raider_manager: RaiderManager
 
 func _ready() -> void:
+    assert(grid.tile_set != null, "Grid TileSet is missing")
     cam.position = grid.map_to_local(Vector2i(0, 0))
     hex_map.reveal_area(Vector2i(0, 0), 2)
     print("World._ready: reveal_area executed")


### PR DESCRIPTION
## Summary
- verify Grid uses existing TileSet.tres and include runtime assertion for TileSet availability

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project, config_version 5 expected 4)*
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `wget https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux_headless.64.zip` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c58337c11c8330b1561ca3a503ed35