### PR TITLE
Refactor world tilemap layers

### DIFF
--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -17,9 +17,12 @@ radius = 6
 [node name="Grid" type="TileMap" parent="HexMap"]
 tile_set = ExtResource("2")
 cell_tile_size = Vector2i(96, 84)
-layers/0/name = "Terrain"
-layers/1/name = "Buildings"
-layers/2/name = "Fog"
-layers/2/modulate = Color(1, 1, 1, 0.55)
+
+[node name="Terrain" type="TileMapLayer" parent="HexMap/Grid"]
+
+[node name="Buildings" type="TileMapLayer" parent="HexMap/Grid"]
+
+[node name="Fog" type="TileMapLayer" parent="HexMap/Grid"]
+modulate = Color(1, 1, 1, 0.55)
 
 [node name="Units" type="Node2D" parent="."]


### PR DESCRIPTION
## Summary
- Extract TileMap layers into dedicated TileMapLayer nodes for terrain, buildings, and fog
- Remove deprecated layer properties from the HexMap grid

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5839a417083309267dfca0c06dbbd