### PR TITLE
Refactor tile map layers to node references

### DIFF
--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -4,16 +4,15 @@ class_name FogMap
 ## Name used to identify the fog source within the TileSet.
 const FOG_SOURCE_NAME := "fog"
 
-var tile_map: TileMap
-var fog_layer: int
+var layer: TileMapLayer
 var source_id: int = -1
 
 static var _cached_texture: Texture2D
 static var _cached_source: TileSetAtlasSource
 
-func _init(p_tile_map: TileMap, p_fog_layer: int) -> void:
-    tile_map = p_tile_map
-    fog_layer = p_fog_layer
+func _init(p_layer: TileMapLayer) -> void:
+    layer = p_layer
+    var tile_map: TileMap = layer.get_parent()
     var tset: TileSet = tile_map.tile_set
     if tset == null:
         tset = TileSet.new()
@@ -22,10 +21,10 @@ func _init(p_tile_map: TileMap, p_fog_layer: int) -> void:
     source_id = _get_or_create_fog_source(tset)
 
 func set_fog(coord: Vector2i) -> void:
-    tile_map.set_cell(fog_layer, coord, source_id)
+    layer.set_cell(coord, source_id)
 
 func clear_fog(coord: Vector2i) -> void:
-    tile_map.erase_cell(fog_layer, coord)
+    layer.erase_cell(coord)
 
 ## Generates a fog texture based on the TileSet tile size.
 func _generate_fog_texture(size: Vector2i) -> Texture2D:

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -3,7 +3,6 @@ extends Node2D
 signal tile_clicked(qr: Vector2i)
 
 @onready var cam: Camera2D = $Camera2D
-@onready var grid: TileMap = $HexMap/Grid
 @onready var hex_map: HexMap = $HexMap
 @onready var units_root: Node2D = $Units
 
@@ -15,8 +14,7 @@ const UnitDataBase = preload("res://scripts/units/UnitData.gd")
 var raider_manager: RaiderManager
 
 func _ready() -> void:
-    assert(grid.tile_set != null, "Grid TileSet is missing")
-    cam.position = grid.map_to_local(Vector2i(0, 0))
+    cam.position = hex_map.axial_to_world(Vector2i(0, 0))
     hex_map.reveal_area(Vector2i(0, 0), 2)
     print("World._ready: reveal_area executed")
     hex_map.reveal_all()


### PR DESCRIPTION
## Summary
- Replace layer index usage with direct TileMapLayer nodes in HexMap
- Adjust FogMap to operate on a TileMapLayer instance
- Simplify World script to use HexMap layer references

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c584a863e48330a0c852debd8d7218