### PR TITLE
Use layer nodes in hexmap tests

### DIFF
--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -13,12 +13,20 @@ class DummyHexMap:
         var tilemap := TileMap.new()
         tilemap.name = "Grid"
         tilemap.tile_set = tset
-        tilemap.set_layer_name(0, "Terrain")
-        tilemap.add_layer(1)
-        tilemap.set_layer_name(1, "Buildings")
-        tilemap.add_layer(2)
-        tilemap.set_layer_name(2, "Fog")
-        tilemap.set_layer_modulate(2, Color(1, 1, 1, 0.55))
+
+        var terrain_layer := TileMapLayer.new()
+        terrain_layer.name = "Terrain"
+        tilemap.add_child(terrain_layer)
+
+        var buildings_layer := TileMapLayer.new()
+        buildings_layer.name = "Buildings"
+        tilemap.add_child(buildings_layer)
+
+        var fog_layer := TileMapLayer.new()
+        fog_layer.name = "Fog"
+        fog_layer.modulate = Color(1, 1, 1, 0.55)
+        tilemap.add_child(fog_layer)
+
         add_child(tilemap)
 
         self.grid = tilemap


### PR DESCRIPTION
## Summary
- build a root TileMap with Terrain, Buildings, and Fog layers for hexmap tests
- reference layers directly instead of using numeric indices

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project, config_version 5 is from a more recent version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c585e9a7048330b33c914601e13fd5