### PR TITLE
Refactor HUD layout with panel container

### DIFF
--- a/scenes/ui/Hud.tscn
+++ b/scenes/ui/Hud.tscn
@@ -6,37 +6,67 @@
 [node name="Hud" type="CanvasLayer"]
 script = ExtResource("1")
 
-[node name="ResourcesLabel" type="Label" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 12.0
+offset_top = 12.0
+offset_right = -12.0
+offset_bottom = -12.0
+
+[node name="Panel" type="Panel" parent="MarginContainer"]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/Panel"]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+
+[node name="ResourcesLabel" type="Label" parent="MarginContainer/Panel/HBoxContainer"]
 text = "Money: 0 Ammo: 0"
 
-[node name="TileInfoLabel" type="Label" parent="."]
+[node name="TileInfoLabel" type="Label" parent="MarginContainer/Panel/HBoxContainer"]
 text = "Tile: (0,0) - Empty"
 
-[node name="StartButton" type="Button" parent="."]
+[node name="StartButton" type="Button" parent="MarginContainer/Panel/HBoxContainer"]
 text = "Start"
 
-[node name="PauseButton" type="Button" parent="."]
+[node name="PauseButton" type="Button" parent="MarginContainer/Panel/HBoxContainer"]
 text = "Pause"
 
-[node name="ClockLabel" type="Label" parent="."]
+[node name="ClockLabel" type="Label" parent="MarginContainer/Panel/HBoxContainer"]
 text = "Time: 0"
 
-[node name="PolicyButton" type="Button" parent="."]
+[node name="PolicyButton" type="Button" parent="MarginContainer/Panel/HBoxContainer"]
 text = "Use Policy"
 
-[node name="PolicySelector" type="OptionButton" parent="."]
+[node name="PolicySelector" type="OptionButton" parent="MarginContainer/Panel/HBoxContainer"]
 
-[node name="EventButton" type="Button" parent="."]
+[node name="EventButton" type="Button" parent="MarginContainer/Panel/HBoxContainer"]
 text = "Trigger Event"
 
-[node name="EventSelector" type="OptionButton" parent="."]
+[node name="EventSelector" type="OptionButton" parent="MarginContainer/Panel/HBoxContainer"]
 
-[node name="EventLabel" type="Label" parent="."]
+[node name="EventLabel" type="Label" parent="MarginContainer/Panel/HBoxContainer"]
 text = "No events"
 
-[node name="BuildButton" type="Button" parent="."]
+[node name="BuildButton" type="Button" parent="MarginContainer/Panel/HBoxContainer"]
 text = "Build"
 
-[node name="BuildingSelector" type="OptionButton" parent="."]
+[node name="BuildingSelector" type="OptionButton" parent="MarginContainer/Panel/HBoxContainer"]
 
-[node name="InfoBox" parent="." instance=ExtResource("2")]
+[node name="InfoBox" parent="MarginContainer/Panel/HBoxContainer" instance=ExtResource("2")]

--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -8,19 +8,19 @@ signal pause_pressed
 signal build_pressed
 signal building_selected
 
-@onready var resources_label: Label = $ResourcesLabel
-@onready var tile_info_label: Label = $TileInfoLabel
-@onready var start_button: Button = $StartButton
-@onready var pause_button: Button = $PauseButton
-@onready var clock_label: Label = $ClockLabel
-@onready var policy_button: Button = $PolicyButton
-@onready var event_button: Button = $EventButton
-@onready var event_label: Label = $EventLabel
-@onready var build_button: Button = $BuildButton
-@onready var building_selector: OptionButton = $BuildingSelector
-@onready var policy_selector: OptionButton = $PolicySelector
-@onready var event_selector: OptionButton = $EventSelector
-@onready var info_box: InfoBox = $InfoBox
+@onready var resources_label: Label = $MarginContainer/Panel/HBoxContainer/ResourcesLabel
+@onready var tile_info_label: Label = $MarginContainer/Panel/HBoxContainer/TileInfoLabel
+@onready var start_button: Button = $MarginContainer/Panel/HBoxContainer/StartButton
+@onready var pause_button: Button = $MarginContainer/Panel/HBoxContainer/PauseButton
+@onready var clock_label: Label = $MarginContainer/Panel/HBoxContainer/ClockLabel
+@onready var policy_button: Button = $MarginContainer/Panel/HBoxContainer/PolicyButton
+@onready var event_button: Button = $MarginContainer/Panel/HBoxContainer/EventButton
+@onready var event_label: Label = $MarginContainer/Panel/HBoxContainer/EventLabel
+@onready var build_button: Button = $MarginContainer/Panel/HBoxContainer/BuildButton
+@onready var building_selector: OptionButton = $MarginContainer/Panel/HBoxContainer/BuildingSelector
+@onready var policy_selector: OptionButton = $MarginContainer/Panel/HBoxContainer/PolicySelector
+@onready var event_selector: OptionButton = $MarginContainer/Panel/HBoxContainer/EventSelector
+@onready var info_box: InfoBox = $MarginContainer/Panel/HBoxContainer/InfoBox
 
 var _policies: Array[Policy] = []
 var _events: Array[GameEventBase] = []


### PR DESCRIPTION
## Summary
- Wrap HUD controls in MarginContainer and Panel for themed background
- Update Hud script to match new node paths

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5889e16648330865c8903e6125751