### PR TITLE
Use palette-based tile painting in HexMap

### DIFF
--- a/styles/palette.gd
+++ b/styles/palette.gd
@@ -4,3 +4,11 @@ const BG := Color("#1e1e2e")
 const FG := Color("#cdd6f4")
 const ACCENT := Color("#89b4fa")
 const WARN := Color("#f38ba8")
+
+# Terrain palette
+const WATER := Color("#89dceb")
+const PLAIN := Color("#a6e3a1")
+const FOREST := Color("#a6e3a1")
+const TAIGA := Color("#94e2d5")
+const HILL := Color("#fab387")
+const MOUNTAIN := Color("#cba6f7")


### PR DESCRIPTION
## Summary
- Preload palette and define terrain source IDs
- Add `_paint_cell` helper that modulates tiles by terrain
- Use `_paint_cell` when drawing saved maps and generating tiles
- Extend palette with terrain colors

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: project requires newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68c58a64496c83308bedc4fff7f9922e