### PR TITLE
Add outline shader material for HexMap grid

### DIFF
--- a/resources/GridOutline.tres
+++ b/resources/GridOutline.tres
@@ -1,0 +1,30 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3]
+
+[sub_resource type="Shader" id="1"]
+code = """
+shader_type canvas_item;
+render_mode unshaded;
+
+uniform float line_thickness : hint_range(0.0, 10.0) = 2.0;
+uniform float line_alpha : hint_range(0.0, 1.0) = 0.5;
+
+const vec2 TILE_SIZE = vec2(96.0, 84.0);
+
+void fragment() {
+    vec2 p = FRAGCOORD.xy / TILE_SIZE;
+    p.y /= 0.866025404; // Adjust for hex vertical spacing
+    p.x += p.y * 0.5;
+    vec3 a = abs(vec3(fract(p) - 0.5, 0.0));
+    a.z = a.x + a.y;
+    float edge = min(min(a.x, a.y), min(a.z, 1.0 - a.z));
+    float line = smoothstep(0.0, line_thickness / max(TILE_SIZE.x, TILE_SIZE.y), edge);
+    vec4 base = texture(TEXTURE, UV);
+    vec4 outline = vec4(0.0, 0.0, 0.0, line_alpha);
+    COLOR = mix(outline, base, line);
+}
+"""
+
+[resource]
+shader = SubResource("1")
+shader_parameter/line_thickness = 2.0
+shader_parameter/line_alpha = 0.5

--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://r05bec2uf1ff"]
+[gd_scene load_steps=5 format=3 uid="uid://r05bec2uf1ff"]
 
 [ext_resource type="Script" uid="uid://vrp3a5sbcd7r" path="res://scripts/world/World.gd" id="1"]
 [ext_resource type="TileSet" path="res://resources/TileSet.tres" id="2"]
+[ext_resource type="ShaderMaterial" path="res://resources/GridOutline.tres" id="3"]
 [ext_resource type="Script" uid="uid://bp0hhotxo8l28" path="res://scripts/world/HexMap.gd" id="4"]
 
 [node name="World" type="Node2D"]
@@ -15,6 +16,7 @@ script = ExtResource("4")
 radius = 6
 
 [node name="Grid" type="TileMap" parent="HexMap"]
+material = ExtResource("3")
 tile_set = ExtResource("2")
 cell_tile_size = Vector2i(96, 84)
 


### PR DESCRIPTION
## Summary
- add a shader material resource to draw hex tile outlines with adjustable thickness and alpha
- hook the new material up to the Grid TileMap in `World.tscn`

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c58f42603c83308de31c9288cb68b0