### PR TITLE
feat: add grid outline shader

### DIFF
--- a/resources/HexOutlineMaterial.tres
+++ b/resources/HexOutlineMaterial.tres
@@ -1,0 +1,8 @@
+[gd_resource type="ShaderMaterial" load_steps=2]
+
+[ext_resource type="Shader" path="res://resources/shaders/hex_outline.gdshader" id="1"]
+
+[resource]
+shader = ExtResource("1")
+shader_parameter/line_thickness = 1.0
+shader_parameter/line_alpha = 1.0

--- a/resources/shaders/hex_outline.gdshader
+++ b/resources/shaders/hex_outline.gdshader
@@ -1,0 +1,17 @@
+shader_type canvas_item;
+
+uniform float line_thickness : hint_range(0.0, 10.0) = 1.0;
+uniform float line_alpha : hint_range(0.0, 1.0) = 1.0;
+
+void fragment() {
+    vec4 tex = texture(TEXTURE, UV);
+    vec2 offset = line_thickness * TEXTURE_PIXEL_SIZE;
+    float outline = 0.0;
+    outline += texture(TEXTURE, UV + vec2(offset.x, 0.0)).a;
+    outline += texture(TEXTURE, UV + vec2(-offset.x, 0.0)).a;
+    outline += texture(TEXTURE, UV + vec2(0.0, offset.y)).a;
+    outline += texture(TEXTURE, UV + vec2(0.0, -offset.y)).a;
+    outline = clamp(outline, 0.0, 1.0);
+    float mask = outline * (1.0 - tex.a);
+    COLOR = tex + vec4(0.0, 0.0, 0.0, line_alpha * mask);
+}

--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://r05bec2uf1ff"]
+[gd_scene load_steps=5 format=3 uid="uid://r05bec2uf1ff"]
 
 [ext_resource type="Script" uid="uid://vrp3a5sbcd7r" path="res://scripts/world/World.gd" id="1"]
 [ext_resource type="TileSet" path="res://resources/TileSet.tres" id="2"]
+[ext_resource type="ShaderMaterial" path="res://resources/HexOutlineMaterial.tres" id="3"]
 [ext_resource type="Script" uid="uid://bp0hhotxo8l28" path="res://scripts/world/HexMap.gd" id="4"]
 
 [node name="World" type="Node2D"]
@@ -17,6 +18,7 @@ radius = 6
 [node name="Grid" type="TileMap" parent="HexMap"]
 tile_set = ExtResource("2")
 cell_tile_size = Vector2i(96, 84)
+material = ExtResource("3")
 
 [node name="Terrain" type="TileMapLayer" parent="HexMap/Grid"]
 


### PR DESCRIPTION
## Summary
- create hex grid outline shader with adjustable thickness/alpha
- assign shader material to HexMap grid in World scene

## Testing
- `godot --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5904258e08330851a743efb5eabec