### PR TITLE
Avoid Palette class shadowing

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -3,8 +3,6 @@ class_name HexMap
 
 const TILE_SIZE := Vector2i(96, 84)
 
-const Palette = preload("res://styles/palette.gd")
-
 const TERRAIN_SOURCE_IDS: Dictionary[String, int] = {
     "forest": 0,
     "taiga": 1,

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -2,8 +2,6 @@ extends Node2D
 
 signal tile_clicked(qr: Vector2i)
 
-const Palette = preload("res://styles/palette.gd")
-
 @onready var cam: Camera2D = $Camera2D
 @onready var hex_map: HexMap = $HexMap
 @onready var units_root: Node2D = $Units

--- a/ui/theme_setup.gd
+++ b/ui/theme_setup.gd
@@ -1,7 +1,5 @@
 extends Node
 
-const Palette = preload("res://styles/palette.gd")
-
 func _ready() -> void:
     var theme := Theme.new()
     var font: FontFile = load("res://fonts/Inter-Regular.ttf")


### PR DESCRIPTION
## Summary
- Remove redundant `Palette` preload constants and use the globally registered `Palette` class
- Fixes shadowed identifier warnings in theme setup and world scripts

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c592e3251483309d5befc9f8ecd151