### PR TITLE
Remove Palette preload constants

### DIFF
--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -3,7 +3,6 @@ class_name HexMap
 
 const TILE_SIZE := Vector2i(96, 84)
 
-const Palette = preload("res://styles/palette.gd")
 
 const TERRAIN_SOURCE_IDS: Dictionary[String, int] = {
     "forest": 0,

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -2,7 +2,6 @@ extends Node2D
 
 signal tile_clicked(qr: Vector2i)
 
-const Palette = preload("res://styles/palette.gd")
 const UnitNode   = preload("res://units/scripts/unit_node.gd")
 const UnitData   = preload("res://units/scripts/unit_data.gd")
 

--- a/ui/theme_setup.gd
+++ b/ui/theme_setup.gd
@@ -1,6 +1,5 @@
 extends Node
 
-const Palette = preload("res://styles/palette.gd")
 
 func _ready() -> void:
     var theme := Theme.new()

--- a/units/scripts/unit_node.gd
+++ b/units/scripts/unit_node.gd
@@ -1,7 +1,6 @@
 class_name UnitNode
 extends Node2D
 
-const Palette   = preload("res://styles/palette.gd")
 const UnitData  = preload("res://units/scripts/unit_data.gd")
 
 @onready var icon: Sprite2D         = $Icon

--- a/units/themes/hp_theme.gd
+++ b/units/themes/hp_theme.gd
@@ -1,5 +1,4 @@
 extends Theme
-const Palette = preload("res://styles/palette.gd")
 func _init():
     var fg := StyleBoxFlat.new()
     fg.bg_color = Palette.HP_GREEN


### PR DESCRIPTION
## Summary
- Fix shadowed global identifier warnings by removing redundant `Palette` preloads
- Use global `Palette` class directly across theme and world scripts

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c593abd40883308060fa1b49bda5b3