### PR TITLE
fix: reference existing font

### DIFF
--- a/assets/fonts/README.md
+++ b/assets/fonts/README.md
@@ -1,10 +1,8 @@
-This directory should contain font files used by the project.
+This directory is provided for optional font files used by the project.
 
-To keep the repository lightweight and avoid storing binary assets,
-acquire the following fonts separately and place them in this folder:
-
-- `OpenSans-Regular.ttf`
-- `PressStart2P-Regular.ttf`
+The default theme now references the bundled `fonts/Inter-Regular.ttf`.
+If you wish to experiment with alternative fonts, place them here and
+update `resources/Theme.tres` or other style resources accordingly.
 
 Fonts can be downloaded from [Google Fonts](https://fonts.google.com/)
 or other reliable sources.

--- a/resources/Theme.tres
+++ b/resources/Theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=4 format=3 uid="uid://bwnrt26jf02ih"]
+[gd_resource type="Theme" load_steps=3 format=3 uid="uid://bwnrt26jf02ih"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 content_margin_left = 8.0
@@ -12,10 +12,7 @@ corner_radius_bottom_right = 12
 corner_radius_bottom_left = 12
 
 [sub_resource type="FontFile" id="2"]
-font_path = "res://assets/fonts/OpenSans-Regular.ttf"
-
-[sub_resource type="FontFile" id="3"]
-font_path = "res://assets/fonts/PressStart2P-Regular.ttf"
+font_path = "res://fonts/Inter-Regular.ttf"
 
 [resource]
 Button/styles/disabled = SubResource("1")
@@ -24,4 +21,3 @@ Button/styles/hover = SubResource("1")
 Button/styles/normal = SubResource("1")
 Button/styles/pressed = SubResource("1")
 default_font = SubResource("2")
-fonts/PressStart2P = SubResource("3")


### PR DESCRIPTION
## Summary
- update Theme.tres to use bundled Inter-Regular font and remove unused font references
- clarify assets/fonts README about optional fonts

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c598febed88330b862d96bafdacb0d