### PR TITLE
Use runtime theme assignment

### DIFF
--- a/scenes/units/Unit.tscn
+++ b/scenes/units/Unit.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=4 format=3]
+[gd_scene load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://units/scripts/unit_node.gd" id="1"]
 [ext_resource type="Material" path="res://units/materials/selection_ring.tres" id="2"]
-[ext_resource type="Theme" path="res://units/themes/hp_theme.gd" id="3"]
 
 [node name="Unit" type="Node2D" class="UnitNode"]
 script = ExtResource("1")
@@ -18,7 +17,6 @@ mouse_filter = 2
 visible = false
 
 [node name="HP" type="ProgressBar" parent="."]
-theme = ExtResource("3")
 position = Vector2(-17, -28)
 size = Vector2(34, 6)
 min_value = 0.0

--- a/styles/palette.gd
+++ b/styles/palette.gd
@@ -1,4 +1,5 @@
 class_name Palette
+extends RefCounted
 
 const BG := Color("#1e1e2e")
 const FG := Color("#cdd6f4")
@@ -11,10 +12,10 @@ const FOREST := Color("#94e2d5")
 const TAIGA := Color("#74c7ec")
 const HILL := Color("#fab387")
 
-const TEXT      : Color = Color("#e6e6e9")
-const HP_GREEN  : Color = Color("#22c55e")
-const HP_RED    : Color = Color("#ef4444")
-const SEL_RING  : Color = Color("#7dd3fc")
-const PLAYER    : Color = Color("#60a5fa")
-const RAIDER    : Color = Color("#f87171")
-const NEUTRAL   : Color = Color("#a3a3a3")
+const TEXT := Color("#e6e6e9")
+const HP_GREEN := Color("#22c55e")
+const HP_RED := Color("#ef4444")
+const SEL_RING := Color("#7dd3fc")
+const PLAYER := Color("#60a5fa")
+const RAIDER := Color("#f87171")
+const NEUTRAL := Color("#a3a3a3")

--- a/ui/theme_setup.gd
+++ b/ui/theme_setup.gd
@@ -1,5 +1,6 @@
 extends Node
 
+const Palette = preload("res://styles/palette.gd")
 
 func _ready() -> void:
     var theme := Theme.new()

--- a/units/scripts/unit_node.gd
+++ b/units/scripts/unit_node.gd
@@ -2,6 +2,8 @@ class_name UnitNode
 extends Node2D
 
 const UnitData  = preload("res://units/scripts/unit_data.gd")
+const HPTheme   = preload("res://units/themes/hp_theme.gd")
+const Palette   = preload("res://styles/palette.gd")
 
 @onready var icon: Sprite2D         = $Icon
 @onready var ring: ColorRect        = $SelectionRing
@@ -20,6 +22,7 @@ func _ready():
     icon.modulate = data.faction_color()
     hp_bar.max_value = data.max_hp
     hp_bar.value = data.hp
+    hp_bar.theme = HPTheme.new()
 
 func set_data(d: UnitData) -> void:
     data = d

--- a/units/themes/hp_theme.gd
+++ b/units/themes/hp_theme.gd
@@ -1,4 +1,6 @@
 extends Theme
+
+const Palette = preload("res://styles/palette.gd")
 func _init():
     var fg := StyleBoxFlat.new()
     fg.bg_color = Palette.HP_GREEN


### PR DESCRIPTION
## Summary
- fix palette constants and register as RefCounted
- load HP theme script and assign to unit progress bar at runtime
- preload palette for theme setup

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project at '/workspace/finsim_AA-club/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c598fd4a5883309aaa2eea9c637396