### PR TITLE
Resolve UnitNode class name conflict

### DIFF
--- a/scripts/units/Unit.gd
+++ b/scripts/units/Unit.gd
@@ -1,5 +1,4 @@
 extends Node2D
-class_name UnitNode
 
 const UnitDataBase = preload("res://scripts/units/UnitData.gd")
 


### PR DESCRIPTION
## Summary
- Remove duplicate `class_name UnitNode` from `scripts/units/Unit.gd` so `units/scripts/unit_node.gd` remains canonical

## Testing
- `godot3-server --headless -s tests/test_runner.gd` *(fails: Can't open project config_version 5 from newer engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c598f871f883308f80f42337728a30