### PR TITLE
refactor: resolve UnitData naming conflict

### DIFF
--- a/scripts/units/Unit.gd
+++ b/scripts/units/Unit.gd
@@ -1,8 +1,8 @@
 extends Node2D
 
-const UnitDataBase = preload("res://scripts/units/UnitData.gd")
+const UnitData = preload("res://scripts/units/UnitData.gd")
 
-@export var unit_data: UnitDataBase
+@export var unit_data: UnitData
 var id: String = str(Time.get_unix_time_from_system())
 var type := "kiuasvartija"
 var hp := 100
@@ -15,7 +15,7 @@ func _ready() -> void:
     if unit_data:
         apply_data(unit_data)
 
-func apply_data(d: UnitDataBase) -> void:
+func apply_data(d: UnitData) -> void:
     unit_data = d
     if unit_data:
         type = unit_data.name
@@ -38,7 +38,7 @@ func from_dict(data: Dictionary) -> void:
     pos_qr = data.get("pos_qr", pos_qr)
     var path: String = data.get("data_path", "")
     if path != "":
-        var ud: UnitDataBase = load(path) as UnitDataBase
+        var ud: UnitData = load(path) as UnitData
         if ud:
             apply_data(ud)
     hp = data.get("hp", hp)

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -2,8 +2,8 @@ extends Node2D
 
 signal tile_clicked(qr: Vector2i)
 
-const UnitNode   = preload("res://units/scripts/unit_node.gd")
-const UnitData   = preload("res://units/scripts/unit_data.gd")
+const UnitNode        = preload("res://units/scripts/unit_node.gd")
+const BattleUnitData  = preload("res://units/scripts/unit_data.gd")
 
 @onready var cam: Camera2D = $Camera2D
 @onready var hex_map: HexMap = $HexMap
@@ -12,7 +12,7 @@ const UnitData   = preload("res://units/scripts/unit_data.gd")
 var selected_unit: UnitNode = null
 var unit_scene: PackedScene = preload("res://scenes/units/Unit.tscn")
 
-const UnitDataBase = preload("res://scripts/units/UnitData.gd")
+const UnitData = preload("res://scripts/units/UnitData.gd")
 
 var raider_manager: RaiderManager
 
@@ -111,7 +111,7 @@ func _on_game_tick() -> void:
 
 func spawn_unit_at_center() -> void:
     var u: Node = unit_scene.instantiate()
-    var data_res: UnitDataBase = load("res://resources/units/saunoja.tres")
+    var data_res: UnitData = load("res://resources/units/saunoja.tres")
     if data_res:
         u.apply_data(data_res)
     u.id = UUID.new_uuid_string()
@@ -203,15 +203,15 @@ func _resolve_combat(pos: Vector2i) -> void:
     GameState.tiles[pos] = tile
     GameState.set_hostile(pos, not enemy_left.is_empty())
 
-func spawn_unit(kind: String, grid_pos: Vector2i, faction := UnitData.Faction.PLAYER) -> UnitNode:
+func spawn_unit(kind: String, grid_pos: Vector2i, faction := BattleUnitData.Faction.PLAYER) -> UnitNode:
     var u := UnitNode.new()
-    var d := UnitData.new()
+    var d := BattleUnitData.new()
     d.faction = faction
     match kind:
         "soldier":
             d.name = "Soldier"; d.icon_path = "res://units/art/unit_soldier.svg"; d.max_hp = 12; d.hp = 12
         "raider":
-            d.name = "Raider"; d.icon_path = "res://units/art/unit_raider.svg"; d.faction = UnitData.Faction.RAIDER
+            d.name = "Raider"; d.icon_path = "res://units/art/unit_raider.svg"; d.faction = BattleUnitData.Faction.RAIDER
         "scout":
             d.name = "Scout"; d.icon_path = "res://units/art/unit_scout.svg"; d.move = 4
         _:

--- a/units/scripts/unit_data.gd
+++ b/units/scripts/unit_data.gd
@@ -1,4 +1,4 @@
-class_name UnitData
+class_name BattleUnitData
 enum Faction { PLAYER, RAIDER, NEUTRAL }
 
 var name: String

--- a/units/scripts/unit_node.gd
+++ b/units/scripts/unit_node.gd
@@ -1,7 +1,7 @@
 class_name UnitNode
 extends Node2D
 
-const UnitData  = preload("res://units/scripts/unit_data.gd")
+const BattleUnitData = preload("res://units/scripts/unit_data.gd")
 const HPTheme   = preload("res://units/themes/hp_theme.gd")
 const Palette   = preload("res://styles/palette.gd")
 
@@ -13,7 +13,7 @@ signal selected(unit: UnitNode)
 signal deselected(unit: UnitNode)
 signal hp_changed(unit: UnitNode, hp: int)
 
-var data: UnitData = UnitData.new()
+var data: BattleUnitData = BattleUnitData.new()
 var is_selected: bool = false
 
 func _ready():
@@ -24,7 +24,7 @@ func _ready():
     hp_bar.value = data.hp
     hp_bar.theme = HPTheme.new()
 
-func set_data(d: UnitData) -> void:
+func set_data(d: BattleUnitData) -> void:
     data = d
     if is_inside_tree(): _ready()
 
@@ -42,7 +42,7 @@ func apply_damage(amount: int) -> void:
         (data.hp > data.max_hp/2) ? Palette.HP_GREEN : Palette.HP_RED
     emit_signal("hp_changed", self, data.hp)
 
-func set_faction(f: int) -> void:
+func set_faction(f: BattleUnitData.Faction) -> void:
     data.faction = f
     icon.modulate = data.faction_color()
 


### PR DESCRIPTION
## Summary
- rename battle unit data script to BattleUnitData to avoid clash with core UnitData
- update unit node and world scripts to use BattleUnitData
- simplify Unit.gd to reference UnitData directly

## Testing
- `godot --headless --check-only` *(fails: Parse errors for missing scripts and resources)*

------
https://chatgpt.com/codex/tasks/task_e_68c59b966f40833091986d7725753114