### PR TITLE
Use clamp instead of clampi in UnitNode

### DIFF
--- a/units/scripts/unit_node.gd
+++ b/units/scripts/unit_node.gd
@@ -36,7 +36,7 @@ func set_selected(v: bool) -> void:
     else: emit_signal("deselected", self)
 
 func apply_damage(amount: int) -> void:
-    data.hp = clampi(data.hp - amount, 0, data.max_hp)
+    data.hp = clamp(data.hp - amount, 0, data.max_hp)
     hp_bar.value = data.hp
     hp_bar.get_theme_stylebox("fill", "ProgressBar").bg_color = \
         (data.hp > data.max_hp/2) ? Palette.HP_GREEN : Palette.HP_RED


### PR DESCRIPTION
## Summary
- replace deprecated `clampi` call with `clamp` so `UnitNode` compiles under Godot 4.4

## Testing
- `/tmp/Godot_v4.2.1-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Could not resolve script "res://scripts/events/Event.gd")*

------
https://chatgpt.com/codex/tasks/task_e_68c5c4788598833098e2d80f68352df4