### PR TITLE
feat: support variable speed for GameClock

### DIFF
--- a/autoload/GameClock.gd
+++ b/autoload/GameClock.gd
@@ -11,7 +11,7 @@ var speed_multiplier: float = 1.0
 func _process(delta: float) -> void:
     if not running:
         return
-    time += delta
+    time += delta * speed_multiplier
     _accumulator += delta * speed_multiplier
     while _accumulator >= TICK_INTERVAL:
         _accumulator -= TICK_INTERVAL

--- a/tests/test_game_clock.gd
+++ b/tests/test_game_clock.gd
@@ -17,3 +17,11 @@ func test_process_no_increment_when_stopped(res):
     clock._process(1.0)
     if clock.time != 0.0:
         res.fail("Time should not advance when stopped")
+
+func test_process_respects_speed_multiplier(res):
+    var clock = GameClock.new()
+    clock.set_speed(2.0)
+    clock.start()
+    clock._process(0.5)
+    if clock.time != 1.0:
+        res.fail("Time should scale with speed multiplier")


### PR DESCRIPTION
## Summary
- scale game clock time by the speed multiplier
- add a test verifying time scaling when speed increases

## Testing
- `godot3 --headless --path . -s tests/test_runner.gd` *(fails: project config_version 5 requires Godot 4)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d3fd1a588330aa0185da88b47927