### PR TITLE
Preload unit palette data

### DIFF
--- a/units/scripts/unit_data.gd
+++ b/units/scripts/unit_data.gd
@@ -1,3 +1,4 @@
+const Palette = preload("res://styles/palette.gd")
 class_name BattleUnitData
 enum Faction { PLAYER, RAIDER, NEUTRAL }
 


### PR DESCRIPTION
## Summary
- Preload Palette in unit_data script for faction colors

## Testing
- `godot3-server --headless -s tests/test_runner.gd` (fails: Can't open project, incompatible engine version)


------
https://chatgpt.com/codex/tasks/task_e_68c66b103e20833088669f5042e7189e