### PR TITLE
Simplify HP bar color expression

### DIFF
--- a/scripts/units/Unit.gd
+++ b/scripts/units/Unit.gd
@@ -32,7 +32,7 @@ var hp: int:
         if is_inside_tree():
             hp_bar.value = data.hp
             hp_bar.get_theme_stylebox("fill", "ProgressBar").bg_color = \
-                (data.hp > data.max_hp/2) ? Palette.HP_GREEN : Palette.HP_RED
+                Palette.HP_GREEN if data.hp > data.max_hp / 2 else Palette.HP_RED
         emit_signal("hp_changed", self, data.hp)
         for i in range(GameState.units.size()):
             var u: Dictionary = GameState.units[i]


### PR DESCRIPTION
## Summary
- Refactor HP bar color assignment to use `if/else` expression for clarity

## Testing
- `./Godot_v4.2.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: could not resolve scripts in autoload/EventManager.gd)*

------
https://chatgpt.com/codex/tasks/task_e_68c66c16d2b48330af716d02250eb435