### PR TITLE
refactor: remove redundant preloads

### DIFF
--- a/scripts/units/Unit.gd
+++ b/scripts/units/Unit.gd
@@ -1,10 +1,7 @@
 extends Node2D
 class_name Unit
 
-const BattleUnitData = preload("res://units/scripts/unit_data.gd")
-const UnitData       = preload("res://scripts/units/UnitData.gd")
 const HPTheme   = preload("res://units/themes/hp_theme.gd")
-const Palette   = preload("res://styles/palette.gd")
 
 @onready var icon: Sprite2D      = $Icon
 @onready var ring: ColorRect     = $SelectionRing

--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -2,17 +2,12 @@ extends Node2D
 
 signal tile_clicked(qr: Vector2i)
 
-const Unit        = preload("res://scripts/units/Unit.gd")
-const BattleUnitData  = preload("res://units/scripts/unit_data.gd")
-
 @onready var cam: Camera2D = $Camera2D
 @onready var hex_map: HexMap = $HexMap
 @onready var units_root: Node2D = $Units
 
 var selected_unit: Unit = null
 var unit_scene: PackedScene = preload("res://scenes/units/Unit.tscn")
-
-const UnitData = preload("res://scripts/units/UnitData.gd")
 
 var raider_manager: RaiderManager
 

--- a/ui/theme_setup.gd
+++ b/ui/theme_setup.gd
@@ -1,7 +1,5 @@
 extends Node
 
-const Palette = preload("res://styles/palette.gd")
-
 func _ready() -> void:
     var theme := Theme.new()
     var font: FontFile = load("res://fonts/Inter-Regular.ttf")

--- a/units/themes/hp_theme.gd
+++ b/units/themes/hp_theme.gd
@@ -1,6 +1,5 @@
 extends Theme
 
-const Palette = preload("res://styles/palette.gd")
 func _init():
     var fg := StyleBoxFlat.new()
     fg.bg_color = Palette.HP_GREEN


### PR DESCRIPTION
## Summary
- drop preload constants for globally named classes
- rely on class_name bindings for Palette and unit scripts

## Testing
- `godot -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c673211eb4833087ee24b5db1dea07