### PR TITLE
Add global BattleUnitData class

### DIFF
--- a/units/scripts/unit_data.gd
+++ b/units/scripts/unit_data.gd
@@ -1,5 +1,6 @@
-const Palette = preload("res://styles/palette.gd")
 class_name BattleUnitData
+extends RefCounted
+const Palette = preload("res://styles/palette.gd")
 enum Faction { PLAYER, RAIDER, NEUTRAL }
 
 var name: String


### PR DESCRIPTION
## Summary
- Register BattleUnitData as a globally available class
- Define RefCounted as its base and keep constants/enums after class declaration

## Testing
- `/tmp/Godot_v4.2.1-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Parse Error: Could not resolve script "res://scripts/events/Event.gd" and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c675a68f0483308da7631e1779954b