### PR TITLE
Fix enum casting in Unit.from_dict

### DIFF
--- a/scripts/units/Unit.gd
+++ b/scripts/units/Unit.gd
@@ -114,6 +114,6 @@ func from_dict(d: Dictionary) -> void:
     atk = d.get("atk", atk)
     def = d.get("def", def)
     hp = d.get("hp", data.hp)
-    data.faction = BattleUnitData.Faction(d.get("faction", data.faction))
+    data.faction = d.get("faction", data.faction) as BattleUnitData.Faction
     if is_inside_tree():
         _ready()


### PR DESCRIPTION
## Summary
- cast stored faction dictionary value to `BattleUnitData.Faction` using `as`

## Testing
- `/tmp/godot/Godot_v4.3-stable_linux.x86_64 --headless --path . --check-only` (fails: parse errors)
- `/tmp/godot/Godot_v4.3-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` (fails: parse errors)


------
https://chatgpt.com/codex/tasks/task_e_68c6792983e48330a094b41a0bec016e