### PR TITLE
Handle missing font and remove Palette shadow

### DIFF
--- a/ui/theme_setup.gd
+++ b/ui/theme_setup.gd
@@ -2,8 +2,12 @@ extends Node
 
 func _ready() -> void:
     var theme := Theme.new()
-    var font: FontFile = load("res://fonts/Inter-Regular.ttf")
-    theme.default_font = font
+    var font_path := "res://fonts/Inter-Regular.ttf"
+    if ResourceLoader.exists(font_path):
+        var font: FontFile = load(font_path)
+        theme.default_font = font
+    else:
+        push_warning("Missing %s, using default font" % font_path)
     theme.default_font_size = 18
 
     theme.set_color("font_color", "Label", Palette.FG)

--- a/units/scripts/unit_data.gd
+++ b/units/scripts/unit_data.gd
@@ -1,6 +1,5 @@
 class_name BattleUnitData
 extends RefCounted
-const Palette = preload("res://styles/palette.gd")
 enum Faction { PLAYER, RAIDER, NEUTRAL }
 
 var name: String


### PR DESCRIPTION
## Summary
- Avoid resource errors if Inter font is missing by checking for the file and warning
- Rely on global `Palette` class in `BattleUnitData` instead of shadowing it with a constant

## Testing
- `./tools/download_fonts.sh`
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found: godot4)*

------
https://chatgpt.com/codex/tasks/task_e_68c67a9c8e5c8330aa3bedd8cd3a01ef