### PR TITLE
fix fog modulate and handle missing Inter font

### DIFF
--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -46,7 +46,6 @@ func _get_or_create_fog_source(tset: TileSet) -> int:
         _cached_source = TileSetAtlasSource.new()
         _cached_source.resource_name = FOG_SOURCE_NAME
         _cached_source.texture = _cached_texture
-        _cached_source.modulate = Color(1, 1, 1, 0.55)
         _cached_source.texture_region_size = size
     var src := _cached_source.duplicate()
     return tset.add_source(src)

--- a/ui/theme_setup.gd
+++ b/ui/theme_setup.gd
@@ -6,8 +6,6 @@ func _ready() -> void:
     if ResourceLoader.exists(font_path):
         var font: FontFile = load(font_path)
         theme.default_font = font
-    else:
-        push_warning("Missing %s, using default font" % font_path)
     theme.default_font_size = 18
 
     theme.set_color("font_color", "Label", Palette.FG)


### PR DESCRIPTION
## Summary
- Load Inter font only when downloaded; default to engine font otherwise.
- Remove bundled Inter font and its license, returning to script-based font downloads.
- Drop invalid `modulate` assignment when creating fog TileSet sources.

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*
- `sudo apt-get install -y godot4` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c67eb0dbec8330af9c5909010765b6