### PR TITLE
Refactor HexMap to use TileMapLayer nodes directly

### DIFF
--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -15,16 +15,15 @@ current = true
 script = ExtResource("4")
 radius = 6
 
-[node name="Grid" type="TileMap" parent="HexMap"]
+[node name="Terrain" type="TileMapLayer" parent="HexMap"]
 material = ExtResource("3")
 tile_set = ExtResource("2")
-cell_tile_size = Vector2i(96, 84)
 
-[node name="Terrain" type="TileMapLayer" parent="HexMap/Grid"]
+[node name="Buildings" type="TileMapLayer" parent="HexMap"]
+tile_set = ExtResource("2")
 
-[node name="Buildings" type="TileMapLayer" parent="HexMap/Grid"]
-
-[node name="Fog" type="TileMapLayer" parent="HexMap/Grid"]
+[node name="Fog" type="TileMapLayer" parent="HexMap"]
+tile_set = ExtResource("2")
 modulate = Color(1, 1, 1, 0.55)
 
 [node name="Units" type="Node2D" parent="."]

--- a/scripts/world/FogMap.gd
+++ b/scripts/world/FogMap.gd
@@ -12,12 +12,11 @@ static var _cached_source: TileSetAtlasSource
 
 func _init(p_layer: TileMapLayer) -> void:
     layer = p_layer
-    var tile_map: TileMap = layer.get_parent()
-    var tset: TileSet = tile_map.tile_set
+    var tset: TileSet = layer.tile_set
     if tset == null:
         tset = TileSet.new()
         tset.tile_shape = TileSet.TILE_SHAPE_HEXAGON
-        tile_map.tile_set = tset
+        layer.tile_set = tset
     source_id = _get_or_create_fog_source(tset)
 
 func set_fog(coord: Vector2i) -> void:

--- a/tests/test_hexmap.gd
+++ b/tests/test_hexmap.gd
@@ -10,26 +10,26 @@ class DummyHexMap:
         tset.tile_size = TILE_SIZE
         tset.tile_shape = TileSet.TILE_SHAPE_HEXAGON
 
-        var tilemap := TileMap.new()
-        tilemap.name = "Grid"
-        tilemap.tile_set = tset
-
         var terrain_layer := TileMapLayer.new()
         terrain_layer.name = "Terrain"
-        tilemap.add_child(terrain_layer)
+        terrain_layer.tile_set = tset
 
         var buildings_layer := TileMapLayer.new()
         buildings_layer.name = "Buildings"
-        tilemap.add_child(buildings_layer)
+        buildings_layer.tile_set = tset
 
         var fog_layer := TileMapLayer.new()
         fog_layer.name = "Fog"
+        fog_layer.tile_set = tset
         fog_layer.modulate = Color(1, 1, 1, 0.55)
-        tilemap.add_child(fog_layer)
 
-        add_child(tilemap)
+        add_child(terrain_layer)
+        add_child(buildings_layer)
+        add_child(fog_layer)
 
-        self.grid = tilemap
+        self.terrain_layer = terrain_layer
+        self.buildings_layer = buildings_layer
+        self.fog_layer = fog_layer
 
     func _set_tile(coord: Vector2i) -> void:
         pass


### PR DESCRIPTION
## Summary
- Remove deprecated TileMap container from World scene
- Update HexMap and FogMap scripts to work with TileMapLayer nodes directly
- Adapt tests to instantiate TileMapLayer nodes without a TileMap parent

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: Parse Error: Could not resolve script "res://scripts/events/Event.gd"...)*

------
https://chatgpt.com/codex/tasks/task_e_68c696aa48508330913a576e58dfe193