### PR TITLE
Add Godot-specific .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,14 @@
 .godot/imported/*
 !.godot/imported/*.md5
 .import/
+*.import/
+*.translation
 
 # Exported builds (keep presets file)
 export/
+bin/
+build/
+dist/
 
 # OS / Editor
 .DS_Store


### PR DESCRIPTION
## Summary
- ignore Godot metadata, imported resources, translations, and build outputs

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a35477d08330b5aa203cc4a8e42e