### PR TITLE
Remove outdated script UID references from scenes

### DIFF
--- a/scenes/ui/EventOverlay.tscn
+++ b/scenes/ui/EventOverlay.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://bakkv70rr6dd5"]
 
-[ext_resource type="Script" uid="uid://blihb8r8umsqn" path="res://scripts/ui/EventOverlay.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/ui/EventOverlay.gd" id="1"]
 
 [node name="EventOverlay" type="CanvasLayer"]
 script = ExtResource("1")

--- a/scenes/ui/Hud.tscn
+++ b/scenes/ui/Hud.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://dkay4i5rdr533"]
 
-[ext_resource type="Script" uid="uid://dgj0jwslqh22m" path="res://scripts/ui/Hud.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/ui/Hud.gd" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/ui/InfoBox.tscn" id="2"]
 
 [node name="Hud" type="CanvasLayer"]

--- a/scenes/ui/InfoBox.tscn
+++ b/scenes/ui/InfoBox.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://hr4tr8dsyh61"]
 
-[ext_resource type="Script" uid="uid://b4fojisc3w44o" path="res://scripts/ui/InfoBox.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/ui/InfoBox.gd" id="1"]
 
 [node name="InfoBox" type="Panel"]
 script = ExtResource("1")

--- a/scenes/ui/TutorialOverlay.tscn
+++ b/scenes/ui/TutorialOverlay.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://bbob5dhtp5l3a"]
 
-[ext_resource type="Script" uid="uid://22to120mtbbk" path="res://scripts/ui/TutorialOverlay.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/ui/TutorialOverlay.gd" id="1"]
 
 [node name="TutorialOverlay" type="CanvasLayer"]
 script = ExtResource("1")

--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=5 format=3 uid="uid://r05bec2uf1ff"]
 
-[ext_resource type="Script" uid="uid://vrp3a5sbcd7r" path="res://scripts/world/World.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/world/World.gd" id="1"]
 [ext_resource type="TileSet" path="res://resources/TileSet.tres" id="2"]
 [ext_resource type="ShaderMaterial" path="res://resources/GridOutline.tres" id="3"]
-[ext_resource type="Script" uid="uid://bp0hhotxo8l28" path="res://scripts/world/HexMap.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/world/HexMap.gd" id="4"]
 
 [node name="World" type="Node2D"]
 script = ExtResource("1")


### PR DESCRIPTION
## Summary
- Remove `uid` attributes from `ext_resource` script references in multiple scenes

## Testing
- `godot3 --headless --path . --run-tests` *(fails: Can't open project, config_version 5 is newer than expected 4; X11 Display not available)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a8569980833094683962560d1bb7