### PR TITLE
Fix HP color threshold division

### DIFF
--- a/scripts/units/Unit.gd
+++ b/scripts/units/Unit.gd
@@ -29,7 +29,7 @@ var hp: int:
         if is_inside_tree():
             hp_bar.value = data.hp
             hp_bar.get_theme_stylebox("fill", "ProgressBar").bg_color = \
-                Palette.HP_GREEN if data.hp > data.max_hp / 2 else Palette.HP_RED
+                Palette.HP_GREEN if data.hp > data.max_hp / 2.0 else Palette.HP_RED
         emit_signal("hp_changed", self, data.hp)
         for i in range(GameState.units.size()):
             var u: Dictionary = GameState.units[i]


### PR DESCRIPTION
## Summary
- Use float division for HP threshold in Unit.gd to ensure color transitions happen correctly

## Testing
- `./godot4/Godot_v4.2.1-stable_linux.x86_64 --headless --path . --script tests/test_runner.gd` *(fails: Identifier "Palette" not declared, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a93278e48330816d7cbbbde7f4ad