### PR TITLE
Fix Camera2D limit smoothing property usage

### DIFF
--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -16,7 +16,7 @@ var zoom_smoothing_speed: float = 8.0
 
 func _ready() -> void:
     RenderingServer.set_default_clear_color(Palette.BG)
-    cam.limit_smoothing_enabled = true
+    cam.limit_smoothing = true
     cam.position_smoothing_enabled = true
     cam.position_smoothing_speed = 8.0
     target_zoom = cam.zoom


### PR DESCRIPTION
## Summary
- fix `World.gd` to use `Camera2D.limit_smoothing`

## Testing
- `./godot/Godot_v4.2.2-stable_linux.x86_64 --headless --path . --quit` *(fails: Parse Error: Could not resolve script "res://scripts/events/Event.gd")*
- `./godot/Godot_v4.2.2-stable_linux.x86_64 --headless --path . -s res://tests/test_runner.gd` *(fails: Parse Error: Could not resolve script "res://scripts/events/Event.gd")*

------
https://chatgpt.com/codex/tasks/task_e_68c6ab101a9c83308ba7cd3f41f56636