### PR TITLE
Update camera limit smoothing property for Godot 4

### DIFF
--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -16,7 +16,7 @@ var zoom_smoothing_speed: float = 8.0
 
 func _ready() -> void:
     RenderingServer.set_default_clear_color(Palette.BG)
-    cam.limit_smoothing = true
+    cam.limit_smoothing_enabled = true
     cam.position_smoothing_enabled = true
     cam.position_smoothing_speed = 8.0
     target_zoom = cam.zoom


### PR DESCRIPTION
## Summary
- Replace deprecated `cam.limit_smoothing` with `cam.limit_smoothing_enabled`

## Testing
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless --path . -s tests/test_runner.gd` *(fails: Parse Error: Could not resolve script "res://scripts/events/Event.gd" and related parse errors)*
- `/tmp/godot/Godot_v4.2.1-stable_linux.x86_64 --headless --path . --quit-after 1` *(no output; process hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dff397388330916b3364bfb3f8d7