### PR TITLE
Fix camera smoothing property name

### DIFF
--- a/scripts/world/World.gd
+++ b/scripts/world/World.gd
@@ -16,7 +16,7 @@ var zoom_smoothing_speed: float = 8.0
 
 func _ready() -> void:
     RenderingServer.set_default_clear_color(Palette.BG)
-    cam.limit_smoothing_enabled = true
+    cam.limit_smoothed = true
     cam.position_smoothing_enabled = true
     cam.position_smoothing_speed = 8.0
     target_zoom = cam.zoom


### PR DESCRIPTION
## Summary
- Replace deprecated `limit_smoothing_enabled` with `limit_smoothed` in `World.gd`

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project at ... config_version ... from a more recent version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e1ad17588330aeb36e6c9c9f933e