### PR TITLE
Ensure world map layers use TileSet

### DIFF
--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3]
+[gd_scene load_steps=5 format=3]
 
 [ext_resource type="Script" path="res://scripts/world/World.gd" id="1"]
+[ext_resource type="TileSet" path="res://resources/TileSet.tres" id="2"]
 [ext_resource type="Material" path="res://resources/GridOutline.tres" id="3"]
 [ext_resource type="Script" path="res://scripts/world/HexMap.gd" id="4"]
 
@@ -16,13 +17,13 @@ radius = 6
 
 [node name="Terrain" type="TileMapLayer" parent="HexMap"]
 material = ExtResource("3")
-tile_set = null
+tile_set = ExtResource("2")
 
 [node name="Buildings" type="TileMapLayer" parent="HexMap"]
-tile_set = null
+tile_set = ExtResource("2")
 
 [node name="Fog" type="TileMapLayer" parent="HexMap"]
-tile_set = null
+tile_set = ExtResource("2")
 modulate = Color(1, 1, 1, 0.55)
 
 [node name="Units" type="Node2D" parent="."]

--- a/scripts/world/HexMap.gd
+++ b/scripts/world/HexMap.gd
@@ -2,6 +2,7 @@ extends Node2D
 class_name HexMap
 
 const TILE_SIZE := Vector2i(96, 84)
+const TILE_SET_PATH := "res://resources/TileSet.tres"
 
 
 const TERRAIN_SOURCE_IDS: Dictionary[String, int] = {
@@ -43,6 +44,7 @@ var _rng := RandomNumberGenerator.new()
 signal tile_clicked(cell: Vector2i)
 
 func _ready() -> void:
+    _ensure_tile_sets()
     _update_grid_outline()
     if radius <= 0:
         push_warning("HexMap radius is 0")
@@ -78,6 +80,15 @@ func reveal_all() -> void:
         var t: Dictionary = GameState.tiles[coord]
         t["explored"] = true
         GameState.tiles[coord] = t
+
+func _ensure_tile_sets() -> void:
+    var ts: TileSet = load(TILE_SET_PATH)
+    if terrain_layer.tile_set == null:
+        terrain_layer.tile_set = ts
+    if buildings_layer.tile_set == null:
+        buildings_layer.tile_set = ts
+    if fog_layer.tile_set == null:
+        fog_layer.tile_set = ts
 
 func _update_grid_outline() -> void:
     if terrain_layer.material is ShaderMaterial:


### PR DESCRIPTION
## Summary
- Assign world layers `Terrain`, `Buildings`, and `Fog` to the shared TileSet resource
- Load TileSet at runtime if any map layers lack it

## Testing
- `./godot4/Godot_v4.4.1-stable_linux.x86_64 --headless -s tests/test_runner.gd` *(fails: Could not resolve script "res://scripts/events/Event.gd")*


------
https://chatgpt.com/codex/tasks/task_e_68c6e401df408330a955c3c3916b1a2c