### PR TITLE
fix: register policy resource

### DIFF
--- a/resources/policies/tax_relief.tres
+++ b/resources/policies/tax_relief.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Policy" load_steps=2 format=3 uid="uid://diyq4hv3wb2v6"]
+[gd_resource type="Resource" script_class="Policy" load_steps=2 format=3 uid="uid://diyq4hv3wb2v6"]
 [ext_resource path="res://scripts/policies/Policy.gd" type="Script" id="1"]
 
 [resource]


### PR DESCRIPTION
## Summary
- configure Tax Relief policy as a generic Resource with Policy script

## Testing
- `godot -e --headless --quit`
- `timeout 10s godot --headless`
- `godot --headless -s tests/test_runner.gd` *(fails: Trying to assign an array of type "Array" to a variable of type "Array[Dictionary]")*


------
https://chatgpt.com/codex/tasks/task_e_68c6e52c8ee88330b71fc91d30fd0345