### PR TITLE
Handle missing policies gracefully

### DIFF
--- a/scripts/ui/Hud.gd
+++ b/scripts/ui/Hud.gd
@@ -34,6 +34,7 @@ func _ready() -> void:
     build_button.pressed.connect(func(): build_pressed.emit())
     _populate_buildings()
     _populate_policies()
+    assert(_policies.size() > 0, "No policies loaded during initialization")
     _populate_events()
     building_selector.item_selected.connect(_on_building_selected)
     var popup := building_selector.get_popup()
@@ -118,16 +119,26 @@ func _populate_buildings() -> void:
 func _populate_policies() -> void:
     _policies.clear()
     policy_selector.clear()
+    policy_selector.disabled = false
+    policy_button.disabled = false
     for file in DirAccess.get_files_at("res://resources/policies"):
         if file.get_extension() == "tres":
-            var res := load("res://resources/policies/%s" % file)
+            var path := "res://resources/policies/%s" % file
+            var res := load(path)
             if res == null:
-                push_warning("Failed to load policy resource: res://resources/policies/%s" % file)
+                push_error("Failed to load policy resource: %s" % path)
             elif res is PolicyBase and res.name:
                 policy_selector.add_item(res.name)
                 _policies.append(res)
             else:
-                push_warning("Loaded resource is not a Policy: res://resources/policies/%s" % file)
+                push_error("Loaded resource is not a Policy: %s" % path)
+    if _policies.is_empty():
+        var msg := "No policies available"
+        policy_selector.add_item(msg)
+        policy_selector.select(0)
+        policy_selector.disabled = true
+        policy_button.disabled = true
+        push_warning(msg)
 
 func _populate_events() -> void:
     _events.clear()

--- a/tests/test_policies.gd
+++ b/tests/test_policies.gd
@@ -1,0 +1,15 @@
+extends Node
+
+const PolicyBase := preload("res://scripts/policies/Policy.gd")
+
+func test_at_least_one_policy(res) -> void:
+    var dir := "res://resources/policies"
+    var count := 0
+    for file in DirAccess.get_files_at(dir):
+        if file.get_extension() == "tres":
+            var path := "%s/%s" % [dir, file]
+            var pol := load(path)
+            if pol != null and pol is PolicyBase and pol.name != "":
+                count += 1
+    if count == 0:
+        res.fail("no valid policies found in %s" % dir)

--- a/tests/test_runner.gd
+++ b/tests/test_runner.gd
@@ -20,6 +20,7 @@ var test_script_paths := [
     "res://tests/test_resources.gd",
     "res://tests/test_saunakunnia.gd",
     "res://tests/test_events.gd",
+    "res://tests/test_policies.gd",
     "res://tests/test_world.gd",
     "res://tests/test_battle.gd",
     "res://tests/test_raiders.gd",


### PR DESCRIPTION
## Summary
- Improve HUD policy population to surface load errors and disable UI when no policies exist
- Add assertion and test ensuring at least one policy is available

## Testing
- `godot4 --headless -s tests/test_runner.gd` *(fails: Could not resolve script "res://scripts/events/Event.gd")*

------
https://chatgpt.com/codex/tasks/task_e_68c6e52e16f0833090a74aa4cdfc54c4