### PR TITLE
fix: keep HUD at top

### DIFF
--- a/scenes/ui/Hud.tscn
+++ b/scenes/ui/Hud.tscn
@@ -10,11 +10,11 @@ script = ExtResource("1")
 anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 1.0
-anchor_bottom = 1.0
+anchor_bottom = 0.0
 offset_left = 12.0
 offset_top = 12.0
 offset_right = -12.0
-offset_bottom = -12.0
+offset_bottom = 0.0
 
 [node name="Panel" type="Panel" parent="MarginContainer"]
 anchor_left = 0.0
@@ -35,6 +35,7 @@ offset_left = 0.0
 offset_top = 0.0
 offset_right = 0.0
 offset_bottom = 0.0
+size_flags_vertical = 0
 
 [node name="ResourcesLabel" type="Label" parent="MarginContainer/Panel/HBoxContainer"]
 text = "Money: 0 Ammo: 0"


### PR DESCRIPTION
## Summary
- stop HUD margin container from stretching vertically so HUD stays at top
- shrink HUD layout vertically to align elements at top

## Testing
- `godot3 --headless -s tests/test_runner.gd` *(fails: Can't open project; requires Godot 4)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f6300a44833082a7632428b9e9b4