### PR TITLE
Refactor tile rendering

### DIFF
--- a/autoload/EventManager.gd
+++ b/autoload/EventManager.gd
@@ -5,18 +5,18 @@ extends Node
 
 const GameEventBase := preload("res://scripts/events/Event.gd")
 
-# List of event scripts to ensure their classes are registered with the
+# Paths to event scripts to ensure their classes are registered with the
 # ClassDB before any event resources are loaded.
-const _EVENT_SCRIPTS := [
-    preload("res://scripts/events/ColdSnap.gd"),
-    preload("res://scripts/events/MerchantReturn.gd"),
-    preload("res://scripts/events/Rain.gd"),
-    preload("res://scripts/events/RuneDiscovery.gd"),
-    preload("res://scripts/events/RunePower.gd"),
-    preload("res://scripts/events/SaunaDiplomacy.gd"),
-    preload("res://scripts/events/Trader.gd"),
-    preload("res://scripts/events/HeatWave.gd"),
-    preload("res://scripts/events/RunBoom.gd"),
+const _EVENT_SCRIPT_PATHS := [
+    "res://scripts/events/ColdSnap.gd",
+    "res://scripts/events/MerchantReturn.gd",
+    "res://scripts/events/Rain.gd",
+    "res://scripts/events/RuneDiscovery.gd",
+    "res://scripts/events/RunePower.gd",
+    "res://scripts/events/SaunaDiplomacy.gd",
+    "res://scripts/events/Trader.gd",
+    "res://scripts/events/HeatWave.gd",
+    "res://scripts/events/RunBoom.gd",
 ]
 
 var events: Array = []
@@ -26,8 +26,10 @@ var _ticks_until_event: int = 0
 const OVERLAY_SCENE := preload("res://scenes/ui/EventOverlay.tscn")
 
 func _ready() -> void:
-    for script in _EVENT_SCRIPTS:
-        script.new()  # ensures class_name is registered
+    for path in _EVENT_SCRIPT_PATHS:
+        var script = load(path)
+        if script:
+            script.new()  # ensures class_name is registered
     _load_events()
     GameClock.tick.connect(_on_tick)
     _schedule_next_event()

--- a/scripts/events/Event.gd
+++ b/scripts/events/Event.gd
@@ -1,4 +1,4 @@
-extends Action
+extends "res://scripts/core/Action.gd"
 class_name GameEvent
 
 @export var name: String = ""

--- a/scripts/world/HexTile.gd
+++ b/scripts/world/HexTile.gd
@@ -1,21 +1,16 @@
 extends Node2D
 
+const Terrain = preload("res://scripts/world/Terrain.gd")
+
 @export var q: int = 0
 @export var r: int = 0
-@export var terrain: String = "plain"
+@export var terrain: String = Terrain.PLAIN
 @export var resource: String = ""
 
 @onready var sprite: Sprite2D = $Sprite
-
-const TERRAIN_TEXTURES := {
-    "water": preload("res://assets/tiles/lake.svg"),
-    "mountain": preload("res://assets/tiles/hill.svg"),
-    "grass": preload("res://assets/tiles/forest.svg"),
-}
 
 func _ready() -> void:
     update_sprite()
 
 func update_sprite() -> void:
-    var tex: Texture2D = TERRAIN_TEXTURES.get(terrain, TERRAIN_TEXTURES["grass"])
-    sprite.texture = tex
+    sprite.texture = Terrain.get_texture(terrain)

--- a/scripts/world/MapGenerator.gd
+++ b/scripts/world/MapGenerator.gd
@@ -1,5 +1,7 @@
 extends Node2D
 
+const Terrain = preload("res://scripts/world/Terrain.gd")
+
 @export var map_width: int = 10
 @export var map_height: int = 10
 @export var generator_seed: int = 0
@@ -25,11 +27,11 @@ func _generate_and_store() -> void:
         for q in map_width:
             var hex: Node2D = hex_tile_scene.instantiate() as Node2D
             var noise_val: float = noise.get_noise_2d(float(q), float(r))
-            var terrain_type := "water"
+            var terrain_type := Terrain.WATER
             if noise_val > 0.4:
-                terrain_type = "mountain"
+                terrain_type = Terrain.MOUNTAIN
             elif noise_val > 0.0:
-                terrain_type = "grass"
+                terrain_type = Terrain.GRASS
             var resource_type := ""
             var roll := RNG.randf()
             if roll < 0.1:
@@ -57,7 +59,7 @@ func _draw_from_saved() -> void:
         var hex: Node2D = hex_tile_scene.instantiate() as Node2D
         hex.q = coord.x
         hex.r = coord.y
-        hex.terrain = data.get("terrain", "water")
+        hex.terrain = data.get("terrain", Terrain.WATER)
         hex.resource = data.get("resource", "")
         hex.update_sprite()
         hex.position = HexUtils.axial_to_world(coord.x, coord.y, hex_radius)

--- a/scripts/world/Terrain.gd
+++ b/scripts/world/Terrain.gd
@@ -1,0 +1,24 @@
+class_name Terrain
+extends RefCounted
+
+const WATER := "water"
+const MOUNTAIN := "mountain"
+const GRASS := "grass"
+const TAIGA := "taiga"
+const TOWN := "town"
+const RUINS := "ruins"
+const PLAIN := "plain"
+
+const _TEXTURES := {
+    WATER: preload("res://assets/tiles/lake.svg"),
+    MOUNTAIN: preload("res://assets/tiles/hill.svg"),
+    GRASS: preload("res://assets/tiles/forest.svg"),
+    TAIGA: preload("res://assets/tiles/taiga.svg"),
+    TOWN: preload("res://assets/tiles/town.svg"),
+    RUINS: preload("res://assets/tiles/ruins.svg"),
+    PLAIN: preload("res://assets/tiles/forest.svg"),
+}
+
+static func get_texture(t: String) -> Texture2D:
+    return _TEXTURES.get(t, _TEXTURES[GRASS])
+

--- a/tests/test_action.gd
+++ b/tests/test_action.gd
@@ -1,4 +1,5 @@
 extends Node
+var Resources = preload("res://scripts/core/Resources.gd")
 
 const GameEventBase = preload("res://scripts/events/Event.gd")
 

--- a/tests/test_battle.gd
+++ b/tests/test_battle.gd
@@ -1,4 +1,5 @@
 extends Node
+var Resources = preload("res://scripts/core/Resources.gd")
 
 func _remove_save(gs) -> void:
     if FileAccess.file_exists(gs.SAVE_PATH):

--- a/tests/test_building.gd
+++ b/tests/test_building.gd
@@ -1,5 +1,6 @@
 extends Node
 var Building = preload("res://scripts/core/Building.gd")
+var Resources = preload("res://scripts/core/Resources.gd")
 
 func test_upgrade_increments_level(res):
     var building = Building.new()

--- a/tests/test_events.gd
+++ b/tests/test_events.gd
@@ -1,4 +1,5 @@
 extends Node
+var Resources = preload("res://scripts/core/Resources.gd")
 const GameEventBase = preload("res://scripts/events/Event.gd")
 
 class DummyEvent:

--- a/tests/test_game_state.gd
+++ b/tests/test_game_state.gd
@@ -1,4 +1,5 @@
 extends Node
+var Resources = preload("res://scripts/core/Resources.gd")
 func _remove_save(gs) -> void:
     if FileAccess.file_exists(gs.SAVE_PATH):
         DirAccess.remove_absolute(gs.SAVE_PATH)

--- a/tests/test_raiders.gd
+++ b/tests/test_raiders.gd
@@ -1,4 +1,5 @@
 extends Node
+var Resources = preload("res://scripts/core/Resources.gd")
 
 func _setup_world():
     var tree = Engine.get_main_loop()

--- a/tests/test_resources.gd
+++ b/tests/test_resources.gd
@@ -1,4 +1,5 @@
 extends Node
+var Resources = preload("res://scripts/core/Resources.gd")
 
 func test_game_state_resources(res) -> void:
     var gs = Engine.get_main_loop().root.get_node("GameState")

--- a/tests/test_saunakunnia.gd
+++ b/tests/test_saunakunnia.gd
@@ -1,4 +1,5 @@
 extends Node
+var Resources = preload("res://scripts/core/Resources.gd")
 
 func test_saunakunnia_resets(res) -> void:
     var tree = Engine.get_main_loop()

--- a/tests/test_sisu.gd
+++ b/tests/test_sisu.gd
@@ -1,4 +1,5 @@
 extends Node
+var Resources = preload("res://scripts/core/Resources.gd")
 
 func _remove_save(gs) -> void:
     if FileAccess.file_exists(gs.SAVE_PATH):

--- a/ui/theme_setup.gd
+++ b/ui/theme_setup.gd
@@ -1,5 +1,7 @@
 extends Node
 
+const Palette = preload("res://styles/palette.gd")
+
 func _ready() -> void:
     var theme := Theme.new()
     var font_path := "res://fonts/Inter-Regular.ttf"


### PR DESCRIPTION
## Summary
- Centralize terrain definitions and textures in a new `Terrain` helper
- Use shared terrain constants in map generation and tile sprites
- Load palette and event scripts explicitly to avoid missing-class errors

## Testing
- `godot --headless --path . -s tests/test_runner.gd` *(fails: Could not find base class "GameEvent" and missing types)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fa3a81788330aa2050db3d0cf80a